### PR TITLE
Update to 0.15.0

### DIFF
--- a/com.authormore.penpotdesktop.yml
+++ b/com.authormore.penpotdesktop.yml
@@ -52,8 +52,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/author-more/penpot-desktop.git
-        tag: v0.14.1
-        commit: 7f1b6bd0d153bd6573093adb1ebf9e1919cabead
+        tag: v0.15.0
+        commit: e6edcdb7d3fd1ed9b3e1a1808f47c434b888dfcd
         dest: main
         x-checker-data:
           type: git

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,16 +1,23 @@
 [
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v36.2.0/SHASUMS256.txt",
-        "sha256": "4303b7d1f5fec4989c8fdc8ae599e354d15cf3fad301ed8204f3498addc0c3d2",
-        "dest-filename": "SHASUMS256.txt-36.2.0",
+        "url": "https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2",
+        "sha512": "3178339530c41277490774c16ef779b8540effc81a20da351df7a7f2f79fe6babf54754f781eb7baebffb8ee7ef0616c009feb6aebba5c1efd4ba2b8f9a5dcfb",
+        "dest-filename": "339530c41277490774c16ef779b8540effc81a20da351df7a7f2f79fe6babf54754f781eb7baebffb8ee7ef0616c009feb6aebba5c1efd4ba2b8f9a5dcfb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/78"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v36.2.1/SHASUMS256.txt",
+        "sha256": "878fffe53f4ec6b74d26725c74267a1edeac03bbf0e9ec5afb646a7e9c8c9340",
+        "dest-filename": "SHASUMS256.txt-36.2.1",
         "dest": "flatpak-node/cache/electron"
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v36.2.0/electron-v36.2.0-linux-arm64.zip",
-        "sha256": "34705bb8645a64e33861cca51693afd02b5f74e9bbb3a9e6be76fec9ffed3328",
-        "dest-filename": "electron-v36.2.0-linux-arm64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v36.2.1/electron-v36.2.1-linux-arm64.zip",
+        "sha256": "ffb5f17ea6a7c2bc99f50b139c840a9d1188d9ddb90b68673256f6b07065fe05",
+        "dest-filename": "electron-v36.2.1-linux-arm64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "aarch64"
@@ -18,9 +25,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v36.2.0/electron-v36.2.0-linux-armv7l.zip",
-        "sha256": "7d7c2a4fced66e3f1373810b66b2185f4bc9e27aa0d1ea910c52397b63c2e4d5",
-        "dest-filename": "electron-v36.2.0-linux-armv7l.zip",
+        "url": "https://github.com/electron/electron/releases/download/v36.2.1/electron-v36.2.1-linux-armv7l.zip",
+        "sha256": "2d617b8277c74ddcfbb6db031983f333dff7b804c971bb5df8d466a2a66ac38c",
+        "dest-filename": "electron-v36.2.1-linux-armv7l.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "arm"
@@ -28,9 +35,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v36.2.0/electron-v36.2.0-linux-x64.zip",
-        "sha256": "013dface80733221d4153aaf538e8969b93f50d68798d7de2425d5e758e6956b",
-        "dest-filename": "electron-v36.2.0-linux-x64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v36.2.1/electron-v36.2.1-linux-x64.zip",
+        "sha256": "6ede19133495925c6fd39dcc161d255372a1cd0d2dc8c131929233584498be35",
+        "dest-filename": "electron-v36.2.1-linux-x64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "x86_64"
@@ -45,136 +52,136 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-        "sha512": "4499481d1b9e420c168ad5a017c39d1581995f7dbc031e4109e98d1a5a877e9967453f444a2f0990596f69561b4be52e6d563a769bfcec5b36bb9336f6234555",
-        "dest-filename": "481d1b9e420c168ad5a017c39d1581995f7dbc031e4109e98d1a5a877e9967453f444a2f0990596f69561b4be52e6d563a769bfcec5b36bb9336f6234555",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/99"
+        "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+        "sha512": "72343b66543432fddbe3b84006e4debf24ee60de22fa5a09286795f5f95c0a020adfb7025d187e2f56ddde20479729deae143b0610a49f604f6d050bfab1aa16",
+        "dest-filename": "3b66543432fddbe3b84006e4debf24ee60de22fa5a09286795f5f95c0a020adfb7025d187e2f56ddde20479729deae143b0610a49f604f6d050bfab1aa16",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/34"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-        "sha512": "11deb553a5c973709545f904449583cf8749c0a7bb88b9a626c6ce1aef704a5a0d485b6d1d5d08f20e940206fbaa72b9972e5b18b3dde285d997109d00d04e59",
-        "dest-filename": "b553a5c973709545f904449583cf8749c0a7bb88b9a626c6ce1aef704a5a0d485b6d1d5d08f20e940206fbaa72b9972e5b18b3dde285d997109d00d04e59",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/11/de"
+        "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+        "sha512": "0f684ff5e03e4aac75901660cf1661d32d6dadbb94f89a03922130aa1437ea7a1d62a270c842213d274c35dee53a6ff88a8ef696e4cf587db461d6b4c4eb94a3",
+        "dest-filename": "4ff5e03e4aac75901660cf1661d32d6dadbb94f89a03922130aa1437ea7a1d62a270c842213d274c35dee53a6ff88a8ef696e4cf587db461d6b4c4eb94a3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/68"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.0.tgz",
-        "sha512": "b7f7c2acb56ef91bb4d61d03b658076576c757663c80aa1c4d1e5e9433aa21153341dd3fea1a6dd952163a3f5bdcd0e8ef2e3f81fc5e476cd1b57abfa8eea252",
-        "dest-filename": "c2acb56ef91bb4d61d03b658076576c757663c80aa1c4d1e5e9433aa21153341dd3fea1a6dd952163a3f5bdcd0e8ef2e3f81fc5e476cd1b57abfa8eea252",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/f7"
+        "url": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
+        "sha512": "2d751d34892ca72c6b955e950c7581982651b6411546904ac62d86b70dc9e787065a12c24e8b950ff43a652692bddd9868339b58af260e3af3dd320ab5a40c00",
+        "dest-filename": "1d34892ca72c6b955e950c7581982651b6411546904ac62d86b70dc9e787065a12c24e8b950ff43a652692bddd9868339b58af260e3af3dd320ab5a40c00",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/75"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.0.tgz",
-        "sha512": "f48da4289c1c00fc0ca008f7f21c2a1571b40b34b62a3f92001c8f510d129474df6fb554858566a3b1b6c36b41aea98e7fb3c577a32967f6b5190268f276bc93",
-        "dest-filename": "a4289c1c00fc0ca008f7f21c2a1571b40b34b62a3f92001c8f510d129474df6fb554858566a3b1b6c36b41aea98e7fb3c577a32967f6b5190268f276bc93",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/8d"
+        "url": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz",
+        "sha512": "fc064724be85e81fc6f79f42b0c033acf28a6637848805627d1c84c17c5c4faaada9b3f01b0fa243198d4be06efa2d3d382b5d3515baa4da41be03ebb4cafd11",
+        "dest-filename": "4724be85e81fc6f79f42b0c033acf28a6637848805627d1c84c17c5c4faaada9b3f01b0fa243198d4be06efa2d3d382b5d3515baa4da41be03ebb4cafd11",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/06"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.0.tgz",
-        "sha512": "fabe59bc3ff48500b7c3954e1c9846702a2888055dca716509ed9de88f5d53e3ef5dd5773be7d4e2f8a9560fba8722db414b821fcda6cf71e74ff701413618b8",
-        "dest-filename": "59bc3ff48500b7c3954e1c9846702a2888055dca716509ed9de88f5d53e3ef5dd5773be7d4e2f8a9560fba8722db414b821fcda6cf71e74ff701413618b8",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/be"
+        "url": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
+        "sha512": "d23bc9e2ef9ea863c1233cd276a28d5f5aef75b494d653cd6257d04112059c180bcb6e81b42d1c167afb73f032bb31313315ac30eb5ee8c9138bd237490de219",
+        "dest-filename": "c9e2ef9ea863c1233cd276a28d5f5aef75b494d653cd6257d04112059c180bcb6e81b42d1c167afb73f032bb31313315ac30eb5ee8c9138bd237490de219",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/3b"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.0.tgz",
-        "sha512": "90d88d538fdb84443fc2eb48d6da75a555b5990d106c08df3d1a39bfc49ac68555f80461901f168e0dc14ac78d60408fcd659f83f583a901887d5d5168115066",
-        "dest-filename": "8d538fdb84443fc2eb48d6da75a555b5990d106c08df3d1a39bfc49ac68555f80461901f168e0dc14ac78d60408fcd659f83f583a901887d5d5168115066",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/d8"
+        "url": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
+        "sha512": "9970e794976f0f348e6da7e362b392bd9070903d3572a07881b9e716e5723691943398a3c14febffabaa52605700038a45fc848e9906559c5a0ec0959c7020cb",
+        "dest-filename": "e794976f0f348e6da7e362b392bd9070903d3572a07881b9e716e5723691943398a3c14febffabaa52605700038a45fc848e9906559c5a0ec0959c7020cb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/99/70"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.0.tgz",
-        "sha512": "7ee2de23e119f71dafffe4d72808e994125623d08dac79f28b99ef510190b78591930c3f77de68551b1cf5a8e9b78c45ac59aa31991dff10501d90ef00b218ec",
-        "dest-filename": "de23e119f71dafffe4d72808e994125623d08dac79f28b99ef510190b78591930c3f77de68551b1cf5a8e9b78c45ac59aa31991dff10501d90ef00b218ec",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7e/e2"
+        "url": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
+        "sha512": "61f27222a20a588eb8320be7fec13b157bd5310111fc277eb3785991ee9c235c60353fdfe99033e6178d0f442d7df1fe29b72a0305c3104d7fe678986b261a40",
+        "dest-filename": "7222a20a588eb8320be7fec13b157bd5310111fc277eb3785991ee9c235c60353fdfe99033e6178d0f442d7df1fe29b72a0305c3104d7fe678986b261a40",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/f2"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.0.tgz",
-        "sha512": "10ea40f08111a50b2dc70a7f5869c302b03b4bec2564379378a8bdf1630ebda0cb29b8e9b6e1d674e618afbf7488eee44c289fff3f7bd4f28f2363e458c7cec6",
-        "dest-filename": "40f08111a50b2dc70a7f5869c302b03b4bec2564379378a8bdf1630ebda0cb29b8e9b6e1d674e618afbf7488eee44c289fff3f7bd4f28f2363e458c7cec6",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/ea"
+        "url": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
+        "sha512": "912263df8469d7422d3fe121f68088b62b8dfc7c0640c5c19c8464ebd8dd3b0116f65956f45972a9c5986c73d21a87e68eca9ea316b7f14684039b6c6e6d895b",
+        "dest-filename": "63df8469d7422d3fe121f68088b62b8dfc7c0640c5c19c8464ebd8dd3b0116f65956f45972a9c5986c73d21a87e68eca9ea316b7f14684039b6c6e6d895b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/22"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.0.tgz",
-        "sha512": "2f626ff72520fc8fa3177ce290e574add88752e97d5f76bfa14e4721784024b136f935d39c405fa983fd1b9c8cc3f61be344a747beb88387f20cae96476c6da7",
-        "dest-filename": "6ff72520fc8fa3177ce290e574add88752e97d5f76bfa14e4721784024b136f935d39c405fa983fd1b9c8cc3f61be344a747beb88387f20cae96476c6da7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/62"
+        "url": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
+        "sha512": "01c78e84485e901510e5dceb5610c3b1b31a6392eab4df2cd66a929d3d8acf5111bd566436286bb3749f93525efebc5135b5d817329948768fb042490c957c76",
+        "dest-filename": "8e84485e901510e5dceb5610c3b1b31a6392eab4df2cd66a929d3d8acf5111bd566436286bb3749f93525efebc5135b5d817329948768fb042490c957c76",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/01/c7"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.0.tgz",
-        "sha512": "fbf3592b258a49fdfd15e369aa17cc79b99a2dad4ff748b536b6f54ab03ba1253918d37f964b00e33ebe6539ec7edd3561f85165260c6e01ac0115ef92bfd52d",
-        "dest-filename": "592b258a49fdfd15e369aa17cc79b99a2dad4ff748b536b6f54ab03ba1253918d37f964b00e33ebe6539ec7edd3561f85165260c6e01ac0115ef92bfd52d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/f3"
+        "url": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
+        "sha512": "e763c56ec97ed44bccba89195cb4653ac75c2c77f5d22b133e55b0a18d4540889d4ec4ef8ca5d55d86fb02fb695a40f344ed99b2a2203caedb23df31f0b45413",
+        "dest-filename": "c56ec97ed44bccba89195cb4653ac75c2c77f5d22b133e55b0a18d4540889d4ec4ef8ca5d55d86fb02fb695a40f344ed99b2a2203caedb23df31f0b45413",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/63"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.0.tgz",
-        "sha512": "e2bbe69b77dff3549f6fe99c593e562a5c8e6be1dddf75926e2ad35547abd308d2d47bff1f3af4ed4bf550b215f4392299928dc8ec179f9f7773e87c96c0d03d",
-        "dest-filename": "e69b77dff3549f6fe99c593e562a5c8e6be1dddf75926e2ad35547abd308d2d47bff1f3af4ed4bf550b215f4392299928dc8ec179f9f7773e87c96c0d03d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/bb"
+        "url": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
+        "sha512": "f55f7d10a1b7bbbcfe144a1ee22920abb6064424ae90072f98a42e4ed5328983e739df5adbf1fd024d49f67240d470a1450a7d380fec20a3ee8064be14afe4d4",
+        "dest-filename": "7d10a1b7bbbcfe144a1ee22920abb6064424ae90072f98a42e4ed5328983e739df5adbf1fd024d49f67240d470a1450a7d380fec20a3ee8064be14afe4d4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/5f"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.0.tgz",
-        "sha512": "aacff9562f5b6237fe655e346ef742c819f90ef6ee7a5851eaa7b02c4f01878efa17b2a73722df74cfc44c9e1ca7de9681e787a3ab5eb00d933174b4b21e57e0",
-        "dest-filename": "f9562f5b6237fe655e346ef742c819f90ef6ee7a5851eaa7b02c4f01878efa17b2a73722df74cfc44c9e1ca7de9681e787a3ab5eb00d933174b4b21e57e0",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/cf"
+        "url": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
+        "sha512": "f8f30b42f8d15e253e01ed1673ea7df44a0612eb73497155c107dade344d5192cd5b9a1d640cac79bf76392053282bbef60199889012b7be828f774b4ed71376",
+        "dest-filename": "0b42f8d15e253e01ed1673ea7df44a0612eb73497155c107dade344d5192cd5b9a1d640cac79bf76392053282bbef60199889012b7be828f774b4ed71376",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/f3"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.0.tgz",
-        "sha512": "60d20a01ce045ef35e02fc9e127ce0be6d55c807b4fdbdd66b1ee98c94b05ee86a210d7fb76843dce6115dbe83e7f19f7c8bda5fcd916e30fe9d6b4c6422cbed",
-        "dest-filename": "0a01ce045ef35e02fc9e127ce0be6d55c807b4fdbdd66b1ee98c94b05ee86a210d7fb76843dce6115dbe83e7f19f7c8bda5fcd916e30fe9d6b4c6422cbed",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/d2"
+        "url": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
+        "sha512": "9a600761c3019808090ca59d923206ab9d17e32074a521a9c7238e0f0626a1ec71c62502cb92494fdf6dd7e3c430aecab6c0adcee5982005d8022291fa4fbf27",
+        "dest-filename": "0761c3019808090ca59d923206ab9d17e32074a521a9c7238e0f0626a1ec71c62502cb92494fdf6dd7e3c430aecab6c0adcee5982005d8022291fa4fbf27",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/60"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.0.tgz",
-        "sha512": "eb2c3138661a8dcc4ad72d4c7f3ace9f0b173ba9e712b9daf3c811584977aaa38e3fc303bbf0d37919062d7045219b9167b9a6e72cb1539066794bcca4db5ee7",
-        "dest-filename": "3138661a8dcc4ad72d4c7f3ace9f0b173ba9e712b9daf3c811584977aaa38e3fc303bbf0d37919062d7045219b9167b9a6e72cb1539066794bcca4db5ee7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/2c"
+        "url": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
+        "sha512": "d3725b8dbd4caa5b9a557287291b8685c296b52821dc98b3ab2da524245b46b9d6a5c334e8c626f2d879f57727b3c12a058be8d17a9bfb60e86459606bdeee5d",
+        "dest-filename": "5b8dbd4caa5b9a557287291b8685c296b52821dc98b3ab2da524245b46b9d6a5c334e8c626f2d879f57727b3c12a058be8d17a9bfb60e86459606bdeee5d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/72"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.0.tgz",
-        "sha512": "08b6a7450c2e1b62cf7c556fae44eb051fcbfc3332dfe113b2006a5b53af4719b3a7f6db5495b45f0db72e79c4c6061cb1a16da2cf7aee5ba5d42b1bb27265cd",
-        "dest-filename": "a7450c2e1b62cf7c556fae44eb051fcbfc3332dfe113b2006a5b53af4719b3a7f6db5495b45f0db72e79c4c6061cb1a16da2cf7aee5ba5d42b1bb27265cd",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/08/b6"
+        "url": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
+        "sha512": "18cd26021164e3d23e4ffe540989ece5ac864ad913b785c516b8e37f42f84b6eb1a0c4d291d09ff5944ef1e9f592ea290b88ac0c5b849bb64e9bf59155e12556",
+        "dest-filename": "26021164e3d23e4ffe540989ece5ac864ad913b785c516b8e37f42f84b6eb1a0c4d291d09ff5944ef1e9f592ea290b88ac0c5b849bb64e9bf59155e12556",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/cd"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.0.tgz",
-        "sha512": "219e4813dd21e8349636e34afdcc230012c029dcbcb4ff0e8065466d77b59e80445f9852b2ed34b9194bbba26eaee8978d6273d9d65cf984b0dc7d1467297f98",
-        "dest-filename": "4813dd21e8349636e34afdcc230012c029dcbcb4ff0e8065466d77b59e80445f9852b2ed34b9194bbba26eaee8978d6273d9d65cf984b0dc7d1467297f98",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/9e"
+        "url": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
+        "sha512": "1e796177d0f2bc6886c237e37d3a0c8b576c9f0d445ca18934b4dcb2e18e447cfa492f6cc1182406ca2edf7310da7e75fdba080eb6ec838b4805b4691162b693",
+        "dest-filename": "6177d0f2bc6886c237e37d3a0c8b576c9f0d445ca18934b4dcb2e18e447cfa492f6cc1182406ca2edf7310da7e75fdba080eb6ec838b4805b4691162b693",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/79"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.0.tgz",
-        "sha512": "dc228b530e350aeafc54c8e1d7acbc2dcb0e68a6e642300a096957c7a074bce511129969e9e9bdb8856123c0aff77e2a8b091b8b6faebfe99564f9d7262d68f4",
-        "dest-filename": "8b530e350aeafc54c8e1d7acbc2dcb0e68a6e642300a096957c7a074bce511129969e9e9bdb8856123c0aff77e2a8b091b8b6faebfe99564f9d7262d68f4",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/22"
+        "url": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
+        "sha512": "f7c326e629f36d64cab9942bd9a5b8491798e9652e91d597b9986ba9fd5074a3d90420ac5ee1bcedcfa23f46f0b43e830679955508e0a78c21a074558b1c8f06",
+        "dest-filename": "26e629f36d64cab9942bd9a5b8491798e9652e91d597b9986ba9fd5074a3d90420ac5ee1bcedcfa23f46f0b43e830679955508e0a78c21a074558b1c8f06",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/c3"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.0.tgz",
-        "sha512": "469860a1cfe8998662b2836471f68144f42be26c9910784b3f1dbfbd35cd2e3882c384607cf475c04814a49f4e3a60c28afe59c88131869acd2e1b5ea87e05b9",
-        "dest-filename": "60a1cfe8998662b2836471f68144f42be26c9910784b3f1dbfbd35cd2e3882c384607cf475c04814a49f4e3a60c28afe59c88131869acd2e1b5ea87e05b9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/98"
+        "url": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
+        "sha512": "3e1f0837520e1cf483854442497073e38f8222efbad1db85c11b20e87a9a2121474076e606dc55c3866b14d21853310fed6c2b34fc5adbfe6a27ffcd2b514673",
+        "dest-filename": "0837520e1cf483854442497073e38f8222efbad1db85c11b20e87a9a2121474076e606dc55c3866b14d21853310fed6c2b34fc5adbfe6a27ffcd2b514673",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3e/1f"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz",
-        "sha512": "2d18cfeb6de33f27f73e8c9f6f4a21323f08dce4720433b05c0831c553db483d2e9c9b96da62567a245f6908a78ed71c32a0b95b2d4738c7dae1bb4a8db3716e",
-        "dest-filename": "cfeb6de33f27f73e8c9f6f4a21323f08dce4720433b05c0831c553db483d2e9c9b96da62567a245f6908a78ed71c32a0b95b2d4738c7dae1bb4a8db3716e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/18"
+        "url": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
+        "sha512": "ff20ab5860a803549528e92cdb910669d3fd3e78f4a002071a9976c07d8cd98e3a74f336b9e6fcc32095383ecedd609391a2742242afce1975258efeb824f60f",
+        "dest-filename": "ab5860a803549528e92cdb910669d3fd3e78f4a002071a9976c07d8cd98e3a74f336b9e6fcc32095383ecedd609391a2742242afce1975258efeb824f60f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/20"
     },
     {
         "type": "file",
@@ -192,10 +199,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.14.tgz",
-        "sha512": "85ce764247ac50ba9bc53442d6f3a64813756277549227a834c7efa5ef7cf21d0c128186a9b8a390eaafe3fd8cf4fb9f049c624d5a0374198115f5cfa3064342",
-        "dest-filename": "764247ac50ba9bc53442d6f3a64813756277549227a834c7efa5ef7cf21d0c128186a9b8a390eaafe3fd8cf4fb9f049c624d5a0374198115f5cfa3064342",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/ce"
+        "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.18.tgz",
+        "sha512": "d97caf31edcddcdaecf1c577f482842d11d36145852ab9aaa9263553e18c95cd23bea8c8567a3184d7761f826895642771b262d430af6f94cdc59b88d9f1235a",
+        "dest-filename": "af31edcddcdaecf1c577f482842d11d36145852ab9aaa9263553e18c95cd23bea8c8567a3184d7761f826895642771b262d430af6f94cdc59b88d9f1235a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d9/7c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+        "sha512": "cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+        "dest-filename": "0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/1d"
     },
     {
         "type": "file",
@@ -220,10 +234,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz",
-        "sha512": "7fae7de991e912afd8b2451df1e998bce5277bcf628fc990823605039aeedb94306eb44efadd52226a1f743bfb90a3ae5829953ae539b6f7e46e01b1225dc4ff",
-        "dest-filename": "7de991e912afd8b2451df1e998bce5277bcf628fc990823605039aeedb94306eb44efadd52226a1f743bfb90a3ae5829953ae539b6f7e46e01b1225dc4ff",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/ae"
+        "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.0.tgz",
+        "sha512": "556fbe08d4a56703183fb3325c46eb2a3a73130841e640cd6f31ad88f123c18cacab24c217e61b349db5d038f70235ac19257888413036498937dc8666656f9b",
+        "dest-filename": "be08d4a56703183fb3325c46eb2a3a73130841e640cd6f31ad88f123c18cacab24c217e61b349db5d038f70235ac19257888413036498937dc8666656f9b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/6f"
     },
     {
         "type": "file",
@@ -231,6 +245,13 @@
         "sha512": "7caa6ff6483848f9adfa163b49506721850b13d40997c2f7b027dc06c9ea6c9c3007001e4cba2427d4d1b7dcbb6cad09033216db2efc4d5563be74049acff2c8",
         "dest-filename": "6ff6483848f9adfa163b49506721850b13d40997c2f7b027dc06c9ea6c9c3007001e4cba2427d4d1b7dcbb6cad09033216db2efc4d5563be74049acff2c8",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7c/aa"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+        "sha512": "75f65ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9",
+        "dest-filename": "5ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/f6"
     },
     {
         "type": "file",
@@ -262,10 +283,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-        "sha512": "c9f9200f0d4a47aeab913e40f1c8b88abcc3cac37b151a6adedb49a2547cf0ea908a4016ab003c8f9559c9ab3ebe3c81345209ecc7f26c9f6994c20b23652b0b",
-        "dest-filename": "200f0d4a47aeab913e40f1c8b88abcc3cac37b151a6adedb49a2547cf0ea908a4016ab003c8f9559c9ab3ebe3c81345209ecc7f26c9f6994c20b23652b0b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/f9"
+        "url": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+        "sha512": "a886d5d3f259afb8920e3a8073ad08a9b2ddb23f460edd7ac50b560fe07bf1dfc7025bf2b0675967aae92471807364f4150c755fab61b123dd9e888629d36d76",
+        "dest-filename": "d5d3f259afb8920e3a8073ad08a9b2ddb23f460edd7ac50b560fe07bf1dfc7025bf2b0675967aae92471807364f4150c755fab61b123dd9e888629d36d76",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/86"
     },
     {
         "type": "file",
@@ -276,10 +297,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
-        "sha512": "23d5e525ac0575232f5a30edeb092c302ae09ece6080b35f17016f9d286c95e5abbaf5cce75e10c64f15db8e9e7d3c3e7a8f49001bd5cfebb7ab6462028c0ac5",
-        "dest-filename": "e525ac0575232f5a30edeb092c302ae09ece6080b35f17016f9d286c95e5abbaf5cce75e10c64f15db8e9e7d3c3e7a8f49001bd5cfebb7ab6462028c0ac5",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/d5"
+        "url": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
+        "sha512": "1b9243f53bb91c912ee33d94a38687636b0b57ae01ec20cc5f1173ab38e5dcd29de9157349736813cd2393b6349499134e48e2221040aa6958c23b81637b6fa4",
+        "dest-filename": "43f53bb91c912ee33d94a38687636b0b57ae01ec20cc5f1173ab38e5dcd29de9157349736813cd2393b6349499134e48e2221040aa6958c23b81637b6fa4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1b/92"
     },
     {
         "type": "file",
@@ -290,10 +311,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-        "sha512": "640a00e34acd30fc129be01e1e90aaf124e2340c3358b26e3fc5efe021c873dc2ffcf4ae1318ccae68df60d8faf36bd6d0e3a26751cac73be342bf576488ac40",
-        "dest-filename": "00e34acd30fc129be01e1e90aaf124e2340c3358b26e3fc5efe021c873dc2ffcf4ae1318ccae68df60d8faf36bd6d0e3a26751cac73be342bf576488ac40",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/0a"
+        "url": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+        "sha512": "d09fb3816c4737ec5738d588c8f58a14c815b89a19b8688816ef32c64ed1263c64ce91a6ca36b9c1116a64856d8c354e42957e470d223808d83c4d9e4328ebd3",
+        "dest-filename": "b3816c4737ec5738d588c8f58a14c815b89a19b8688816ef32c64ed1263c64ce91a6ca36b9c1116a64856d8c354e42957e470d223808d83c4d9e4328ebd3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/9f"
     },
     {
         "type": "file",
@@ -399,13 +420,6 @@
         "sha512": "f503ad35f7dc385fdcd6c78c0839e37246f747d587706df8b64cbe147a4d28a096d3073fb1c60bc0cb4efa9b721947cc5b4fdbfe7e2a46200b95a14773d3a3ed",
         "dest-filename": "ad35f7dc385fdcd6c78c0839e37246f747d587706df8b64cbe147a4d28a096d3073fb1c60bc0cb4efa9b721947cc5b4fdbfe7e2a46200b95a14773d3a3ed",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/03"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
-        "sha512": "93fd696fbd1e0fadfc6a7a22d1ef305060256cc257caf755e29eb62a8f8467b7817b5c4cc7c5216a4d51e4381fa287ec2b9201067470b1819368b665fbaffe45",
-        "dest-filename": "696fbd1e0fadfc6a7a22d1ef305060256cc257caf755e29eb62a8f8467b7817b5c4cc7c5216a4d51e4381fa287ec2b9201067470b1819368b665fbaffe45",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/fd"
     },
     {
         "type": "file",
@@ -549,10 +563,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-        "sha512": "9c6f7a1b75a9e9a73202026a19ab233836fe69cac8eca96d3e2471cc73d79cfdcd808dbc6e940346fe77a256ea1976df7201796a288798edf1a701294b92ddf6",
-        "dest-filename": "7a1b75a9e9a73202026a19ab233836fe69cac8eca96d3e2471cc73d79cfdcd808dbc6e940346fe77a256ea1976df7201796a288798edf1a701294b92ddf6",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/6f"
+        "url": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+        "sha512": "1ac0822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+        "dest-filename": "822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/c0"
     },
     {
         "type": "file",
@@ -598,10 +612,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/verror/-/verror-1.10.10.tgz",
-        "sha512": "97830cd09a699f5f216fdc6633ac300f5b937528697fd3e7f346974d2b672b50bde20b4fbc9715d85ac399b39050041f27570a64792d910503c04a9a00a5cc32",
-        "dest-filename": "0cd09a699f5f216fdc6633ac300f5b937528697fd3e7f346974d2b672b50bde20b4fbc9715d85ac399b39050041f27570a64792d910503c04a9a00a5cc32",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/83"
+        "url": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+        "sha512": "4650e6f4aefea39b2dbf40a8f22f19446c436eb4f1849b608ea8c5c9587fb5743297fad8b532a59d3bd9f3ca124de611116babc31db426ce244ee282b05914b6",
+        "dest-filename": "e6f4aefea39b2dbf40a8f22f19446c436eb4f1849b608ea8c5c9587fb5743297fad8b532a59d3bd9f3ca124de611116babc31db426ce244ee282b05914b6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/50"
     },
     {
         "type": "file",
@@ -612,59 +626,59 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.0.tgz",
-        "sha512": "fe353d7adb5c9ed901166594cf31a0b029448b66458a290c5f978442c9b120058c3a7e07dc3e2bbc7b2cb2d9801c656fad89da32a7565968346f933a20dfcc4d",
-        "dest-filename": "3d7adb5c9ed901166594cf31a0b029448b66458a290c5f978442c9b120058c3a7e07dc3e2bbc7b2cb2d9801c656fad89da32a7565968346f933a20dfcc4d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/35"
+        "url": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
+        "sha512": "eaee8f960f673ff275191a5efef7238da6e8e947396103c0331b20432182fc8d11bae9221b5c087b7f95b60dc8ad20952439aa2b78fc69daedcd7484351b4582",
+        "dest-filename": "8f960f673ff275191a5efef7238da6e8e947396103c0331b20432182fc8d11bae9221b5c087b7f95b60dc8ad20952439aa2b78fc69daedcd7484351b4582",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/ee"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.0.tgz",
-        "sha512": "07631dcf25b1084dbe4aa8991c08cfa617edfbfdb1d8594ef58071ede284d4109bfaba81950761b40121cc811da331dde790d73e6c417693328052637e38c0f4",
-        "dest-filename": "1dcf25b1084dbe4aa8991c08cfa617edfbfdb1d8594ef58071ede284d4109bfaba81950761b40121cc811da331dde790d73e6c417693328052637e38c0f4",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/07/63"
+        "url": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
+        "sha512": "2ca32b9b008fa0b84ce39674d0ed6e95bea3c3256bda4af75c9a7e1beb5211971b6ae36749c7b0710c2d26a5c38577983c312367c0b54a35e6d35e428ab1261a",
+        "dest-filename": "2b9b008fa0b84ce39674d0ed6e95bea3c3256bda4af75c9a7e1beb5211971b6ae36749c7b0710c2d26a5c38577983c312367c0b54a35e6d35e428ab1261a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/a3"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.0.tgz",
-        "sha512": "8dcff823118d79d5e4986e26c789c94c82dbe933232fae83e35bf279a3d6bc352679843317794ab4dd795ac01e4ebeb971ee263f1c28a4f4a8d72514016c3485",
-        "dest-filename": "f823118d79d5e4986e26c789c94c82dbe933232fae83e35bf279a3d6bc352679843317794ab4dd795ac01e4ebeb971ee263f1c28a4f4a8d72514016c3485",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8d/cf"
+        "url": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
+        "sha512": "ec8b086880de667ee47df93ba970b7a3a67851b95924a577501a64bd1369af9352c8b8e2eedbd372f9a730d62e60bca1dba98df16ef6df1a68de2e0c943df7bc",
+        "dest-filename": "086880de667ee47df93ba970b7a3a67851b95924a577501a64bd1369af9352c8b8e2eedbd372f9a730d62e60bca1dba98df16ef6df1a68de2e0c943df7bc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/8b"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.0.tgz",
-        "sha512": "b76be8bae6102842922ed25a6b96c1e231de85ad8725ccd0e84e485cf0cf808b72f44a9c271a6bd501d0f3a63220fc03c31bd498b7cfd98003439658e2a75d66",
-        "dest-filename": "e8bae6102842922ed25a6b96c1e231de85ad8725ccd0e84e485cf0cf808b72f44a9c271a6bd501d0f3a63220fc03c31bd498b7cfd98003439658e2a75d66",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/6b"
+        "url": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
+        "sha512": "9aff58a50180f2222c9792b250f8be1462e6efe6c0e1f81769e45c14a4434700ccbb88b0ad21de0cf8a9c2e78d5e174821996dc0226ff8d9317ed1026c86567c",
+        "dest-filename": "58a50180f2222c9792b250f8be1462e6efe6c0e1f81769e45c14a4434700ccbb88b0ad21de0cf8a9c2e78d5e174821996dc0226ff8d9317ed1026c86567c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/ff"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.0.tgz",
-        "sha512": "3b921dead19a74064431384ce8bf479957f9850517352c4b54a78625858d86156c7a9b3fd0b75d324a7bfff543933c09ebd94f2f452665d719c20823f5a90968",
-        "dest-filename": "1dead19a74064431384ce8bf479957f9850517352c4b54a78625858d86156c7a9b3fd0b75d324a7bfff543933c09ebd94f2f452665d719c20823f5a90968",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/92"
+        "url": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
+        "sha512": "626c9bc175097201aa800a7a6c4b20a4f5c483a75c0b23f2092af408002e79a711fc20818b6e46dd5f20190da447341104da25ed54249f132cf47bd56bd46f7e",
+        "dest-filename": "9bc175097201aa800a7a6c4b20a4f5c483a75c0b23f2092af408002e79a711fc20818b6e46dd5f20190da447341104da25ed54249f132cf47bd56bd46f7e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/6c"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.0.tgz",
-        "sha512": "a54f550fb6a7482388a0116785319f3b3955150200d575e24291ff09ecea381683a694704e0949cc20ba7d4406a5fc1ecb84f5f3734a845d7f99f6ad6268d1a9",
-        "dest-filename": "550fb6a7482388a0116785319f3b3955150200d575e24291ff09ecea381683a694704e0949cc20ba7d4406a5fc1ecb84f5f3734a845d7f99f6ad6268d1a9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/4f"
+        "url": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
+        "sha512": "63700ff4421f63005be245866feb229af3daa90a13e6826ecf38fd9b48ba14263a48fbe5a26636122e1410c9bbf855ed94d25ba2bf34c629b2b25cda405eb186",
+        "dest-filename": "0ff4421f63005be245866feb229af3daa90a13e6826ecf38fd9b48ba14263a48fbe5a26636122e1410c9bbf855ed94d25ba2bf34c629b2b25cda405eb186",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/70"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.0.tgz",
-        "sha512": "f12f615dabba9d0fec615b42dc3e884880e82734b536c08afa096e5612cdd989013d7fbfd70930c948832a7c51875e79efd5a8388c955a7a3221fdf2188f5113",
-        "dest-filename": "615dabba9d0fec615b42dc3e884880e82734b536c08afa096e5612cdd989013d7fbfd70930c948832a7c51875e79efd5a8388c955a7a3221fdf2188f5113",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/2f"
+        "url": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
+        "sha512": "0ec48534880b4ab73cf60a6ad4b241ec79b5629ba12b4f3a0d10c948dadec1c1af625a165b5bd92c705322f6ab2990dc00e448cbfb96371f0669dfb8a0ca6448",
+        "dest-filename": "8534880b4ab73cf60a6ad4b241ec79b5629ba12b4f3a0d10c948dadec1c1af625a165b5bd92c705322f6ab2990dc00e448cbfb96371f0669dfb8a0ca6448",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/c4"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.0.tgz",
-        "sha512": "d6b6104c22c5173388e4d97473c2d4a494fc1f1a705519fd1380a432c61fb8de9cb6642a1318d24f3cd29344f3d9aa665f2ed653affa7f269955503fb613cdfb",
-        "dest-filename": "104c22c5173388e4d97473c2d4a494fc1f1a705519fd1380a432c61fb8de9cb6642a1318d24f3cd29344f3d9aa665f2ed653affa7f269955503fb613cdfb",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/b6"
+        "url": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
+        "sha512": "6abd2d8d07ce6f3852696dc2dd03664dce687e3d210e8350e575ab0b2eb30f269b76bd135a10a40a5a7eaf2c06363fe8740141573cc9acae2d12ae4ce079aee3",
+        "dest-filename": "2d8d07ce6f3852696dc2dd03664dce687e3d210e8350e575ab0b2eb30f269b76bd135a10a40a5a7eaf2c06363fe8740141573cc9acae2d12ae4ce079aee3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/bd"
     },
     {
         "type": "file",
@@ -696,13 +710,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-        "sha512": "e5cbe0e82b4ac1f81d995a98d562225ca7374356e446a18b8bed96ffa6a8fba63b82efd10b046e021184ce1e41e0a96ccd2b932e0658baa16aa396c89a334a9e",
-        "dest-filename": "e0e82b4ac1f81d995a98d562225ca7374356e446a18b8bed96ffa6a8fba63b82efd10b046e021184ce1e41e0a96ccd2b932e0658baa16aa396c89a334a9e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/cb"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
         "sha512": "aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
         "dest-filename": "6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
@@ -724,17 +731,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-        "sha512": "1f44d2c8534332898c3494019fcc05579602ff6789f955c40b039a759253e79e313fa70e0d91cf5f71fd40c4040b1beb82248e3f5a478f2d6c31641560939438",
-        "dest-filename": "d2c8534332898c3494019fcc05579602ff6789f955c40b039a759253e79e313fa70e0d91cf5f71fd40c4040b1beb82248e3f5a478f2d6c31641560939438",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/44"
+        "url": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+        "sha512": "8d1479c1dca5abc0a439eea17a2d7d186667c4ceab046c05977060d1822d1838a6be31ad02f7599383eee82978bb8220b30b386b57ddd55ab77b3ae19f82a617",
+        "dest-filename": "79c1dca5abc0a439eea17a2d7d186667c4ceab046c05977060d1822d1838a6be31ad02f7599383eee82978bb8220b30b386b57ddd55ab77b3ae19f82a617",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8d/14"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-        "sha512": "e461bfe486d04290bd1699111ac4af648e5061e482ce52477690509ed0acb933b184a0fc96a2a1ae57a0d988bbcaf3087fcd987269aa967f54f15f6ac048897b",
-        "dest-filename": "bfe486d04290bd1699111ac4af648e5061e482ce52477690509ed0acb933b184a0fc96a2a1ae57a0d988bbcaf3087fcd987269aa967f54f15f6ac048897b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/61"
+        "url": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+        "sha512": "9236bc8fb3e39a770e36a693b01f1f43ec04da6494d8327d0f85caa09e4f15621d44c6ba48b48dd5f7f898eaf88c26df452b3147891e222c92254d0df53e6121",
+        "dest-filename": "bc8fb3e39a770e36a693b01f1f43ec04da6494d8327d0f85caa09e4f15621d44c6ba48b48dd5f7f898eaf88c26df452b3147891e222c92254d0df53e6121",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/36"
     },
     {
         "type": "file",
@@ -801,52 +808,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz",
-        "sha512": "12fe238f70fb068f8ed063c3d8d32f265f8f1a20407d2ee95066b09ed04da426f1b699dc7d48b1a858fdcfd2667bb57bb372c11aab166593f9e1fc415f724a27",
-        "dest-filename": "238f70fb068f8ed063c3d8d32f265f8f1a20407d2ee95066b09ed04da426f1b699dc7d48b1a858fdcfd2667bb57bb372c11aab166593f9e1fc415f724a27",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/fe"
+        "url": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
+        "sha512": "8fcee8d23e8ba8f2f7411afcca277a73e4ede600bbc4d7d8a3ab90210928ac00ba32979ac95319ac40f32a6249fc796fec49ce4296919b9de4ea4b43619c81eb",
+        "dest-filename": "e8d23e8ba8f2f7411afcca277a73e4ede600bbc4d7d8a3ab90210928ac00ba32979ac95319ac40f32a6249fc796fec49ce4296919b9de4ea4b43619c81eb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/ce"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz",
-        "sha512": "a42a9eedd7ec405040042d6378a6574168467023c5deb3c25c375fa952a321e581717cf20b588e59975f1611a5f92f4cc84fe4fff0c5982e85cee18052e74d0e",
-        "dest-filename": "9eedd7ec405040042d6378a6574168467023c5deb3c25c375fa952a321e581717cf20b588e59975f1611a5f92f4cc84fe4fff0c5982e85cee18052e74d0e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/2a"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-        "sha512": "9587b81b1ed04fe30a19b0ec03e67e85efd6b5e7f4062c033a52bf5e406b75fb21f49fe33cf5db5f4b44f71f5c976ed39aee608374146d4ad061aff2f8a3873d",
-        "dest-filename": "b81b1ed04fe30a19b0ec03e67e85efd6b5e7f4062c033a52bf5e406b75fb21f49fe33cf5db5f4b44f71f5c976ed39aee608374146d4ad061aff2f8a3873d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/95/87"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-        "sha512": "6c42ffc946ff7cd362353b94cfdefd674620e4bf8bccbc46273f31efd958991e787e64c86faa1bfe13508244272140d62058d9550c25f57b37e7a23a0403077f",
-        "dest-filename": "ffc946ff7cd362353b94cfdefd674620e4bf8bccbc46273f31efd958991e787e64c86faa1bfe13508244272140d62058d9550c25f57b37e7a23a0403077f",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/42"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
-        "sha512": "29581fe17415ad38e1c969b1e9cb5ee11c689cf2d1f689c4c6e7c8d6386fc3f310e0107a22c643e604fc2eafaeffea519169daffa2681e98908a86aa14fe51cf",
-        "dest-filename": "1fe17415ad38e1c969b1e9cb5ee11c689cf2d1f689c4c6e7c8d6386fc3f310e0107a22c643e604fc2eafaeffea519169daffa2681e98908a86aa14fe51cf",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/58"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
-        "sha512": "fb6e67c72cb39c05c5ecd79fdf2d046c17aa98666078dfc1c475f6f51b37f5d8c07da15a96643cf5213a096c83087cc62f4cadff2701b4d3a61935b417219637",
-        "dest-filename": "67c72cb39c05c5ecd79fdf2d046c17aa98666078dfc1c475f6f51b37f5d8c07da15a96643cf5213a096c83087cc62f4cadff2701b4d3a61935b417219637",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/6e"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-        "sha512": "4195b8103986c2562eaf46327ff6f6b86b9c1d031af1a1543fb7aef5d751ef7bef845cade15d159774073dc4cd27c97aa9838177181776705742b1e295f45006",
-        "dest-filename": "b8103986c2562eaf46327ff6f6b86b9c1d031af1a1543fb7aef5d751ef7bef845cade15d159774073dc4cd27c97aa9838177181776705742b1e295f45006",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/95"
+        "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.0.12.tgz",
+        "sha512": "fbf0843c7d5f54a7fa1e8c0152ce8b70022845c8deaa0bc07a8484f9c97b63b2e777243d56218f6226cd93bc2684c1f33601c8b886f0e275800cf3bee268e05b",
+        "dest-filename": "843c7d5f54a7fa1e8c0152ce8b70022845c8deaa0bc07a8484f9c97b63b2e777243d56218f6226cd93bc2684c1f33601c8b886f0e275800cf3bee268e05b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/f0"
     },
     {
         "type": "file",
@@ -927,27 +899,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
-        "sha512": "ec1d51b71f368639d20f83c62c08d559e607ded1c07155260a187ce5ade596d2909ba16b7ac5e1f44ad0a3aa00bfa0aac6db5ccc2dff90483c498e4d96e3ee53",
-        "dest-filename": "51b71f368639d20f83c62c08d559e607ded1c07155260a187ce5ade596d2909ba16b7ac5e1f44ad0a3aa00bfa0aac6db5ccc2dff90483c498e4d96e3ee53",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/1d"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-        "sha512": "5e9363e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
-        "dest-filename": "63e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/93"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-        "sha512": "d36aaf01ac6ff2da7b7c16bf9b0d606bdf0e1a6f9e09bab324e2a846def4b0b99f1048be8f20585530c67c22ff934ebfe04324ff3d358027bb1e8087fdfd8b4e",
-        "dest-filename": "af01ac6ff2da7b7c16bf9b0d606bdf0e1a6f9e09bab324e2a846def4b0b99f1048be8f20585530c67c22ff934ebfe04324ff3d358027bb1e8087fdfd8b4e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/6a"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
         "sha512": "774208fc63bdb9ff657d41c7d8142c8f1cd125905db2382c0625b806f85693fdeaa0ac1016320354dd7d3df5fc1760ffafd3c2313b4b5a3615085ae9798533b3",
         "dest-filename": "08fc63bdb9ff657d41c7d8142c8f1cd125905db2382c0625b806f85693fdeaa0ac1016320354dd7d3df5fc1760ffafd3c2313b4b5a3615085ae9798533b3",
@@ -997,24 +948,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
-        "sha512": "ea9fe07c6d5125241e21bcfc4cae5a3cd928ced818d6ae538261853005dc63c8adb065ba63695dd402ec6795099fcae883b84a177cc7c798906cd43cb8b71197",
-        "dest-filename": "e07c6d5125241e21bcfc4cae5a3cd928ced818d6ae538261853005dc63c8adb065ba63695dd402ec6795099fcae883b84a177cc7c798906cd43cb8b71197",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/9f"
+        "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
+        "sha512": "dbf7a0acd0c39d16b15702b703e709aba50e96a39d79d180ec93ea09e263376663935fd007fe90522ddbef5e12708192ec769f1574f2cc910eaf96f8e08de4bd",
+        "dest-filename": "a0acd0c39d16b15702b703e709aba50e96a39d79d180ec93ea09e263376663935fd007fe90522ddbef5e12708192ec769f1574f2cc910eaf96f8e08de4bd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/f7"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz",
-        "sha512": "ee33e3cc1c041916f035c7a9d2018da4b5c6f4ff78540dc23c06500b3c64157895d863102a5ce231b63ffeb5cf23b58a7e1b2f1a01578d3717741130817c3dc3",
-        "dest-filename": "e3cc1c041916f035c7a9d2018da4b5c6f4ff78540dc23c06500b3c64157895d863102a5ce231b63ffeb5cf23b58a7e1b2f1a01578d3717741130817c3dc3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/33"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-        "sha512": "fcd7fb4f2cd3c7a4b7c9124e6ce015efde7aafc72bdbe3a3f000b976df3048fdc1400a1e5f9f0da07c8253c3fccc690d5d2b634d28ba7f33ba174a4175c61b12",
-        "dest-filename": "fb4f2cd3c7a4b7c9124e6ce015efde7aafc72bdbe3a3f000b976df3048fdc1400a1e5f9f0da07c8253c3fccc690d5d2b634d28ba7f33ba174a4175c61b12",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/d7"
+        "url": "https://registry.npmjs.org/builder-util/-/builder-util-26.0.11.tgz",
+        "sha512": "c4d8d77ec95d5047b5e778750eb683d17bc33a9a864742f978a164751781ede156e47ab2b036457e5cb8adc91d6bacbd745dfd377a643e539b95c7c7286c3eb8",
+        "dest-filename": "d77ec95d5047b5e778750eb683d17bc33a9a864742f978a164751781ede156e47ab2b036457e5cb8adc91d6bacbd745dfd377a643e539b95c7c7286c3eb8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/d8"
     },
     {
         "type": "file",
@@ -1043,13 +987,6 @@
         "sha512": "4a9d5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
         "dest-filename": "5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/9d"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-        "sha512": "fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e",
-        "dest-filename": "3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/2b"
     },
     {
         "type": "file",
@@ -1172,13 +1109,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-        "sha512": "aa20639296cc2cefc72faf32fa5878ab4fced4c6458f6457e97fca98c6b7fa0243df3f96c08d59cc31f2b2fa87192de63fa9b39cf724a579b0d6723d7098f246",
-        "dest-filename": "639296cc2cefc72faf32fa5878ab4fced4c6458f6457e97fca98c6b7fa0243df3f96c08d59cc31f2b2fa87192de63fa9b39cf724a579b0d6723d7098f246",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/20"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
         "sha512": "21f103c70a1622391e5cbd5e5dc0e2a30e146ca8e12ddabafc4b92551f4630deca547debf6043cddeef786ccf535dd53de28dde71bf5c1c59160ef83ea4088db",
         "dest-filename": "03c70a1622391e5cbd5e5dc0e2a30e146ca8e12ddabafc4b92551f4630deca547debf6043cddeef786ccf535dd53de28dde71bf5c1c59160ef83ea4088db",
@@ -1207,6 +1137,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+        "sha512": "291b3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905",
+        "dest-filename": "3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/1b"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
         "sha512": "cc78a0e4dfad3d6011a280676f4671d4c15c75fa7226b7d32776392fe205bd49bcaccef8847cfaeb3d20c34c78b628e1e42a2b2a42940a75bcd91daf9a978244",
         "dest-filename": "a0e4dfad3d6011a280676f4671d4c15c75fa7226b7d32776392fe205bd49bcaccef8847cfaeb3d20c34c78b628e1e42a2b2a42940a75bcd91daf9a978244",
@@ -1228,13 +1165,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
-        "sha512": "0f7b8c1ed19cfdf70ed46b75fcbee2d5edf754ebc3e00f617d02cffba7b077e06f1bf810f38621e287ed12101d8d2320060c062fe8eca694fb258369a3a3071e",
-        "dest-filename": "8c1ed19cfdf70ed46b75fcbee2d5edf754ebc3e00f617d02cffba7b077e06f1bf810f38621e287ed12101d8d2320060c062fe8eca694fb258369a3a3071e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/7b"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
         "sha512": "fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
         "dest-filename": "efe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
@@ -1246,27 +1176,6 @@
         "sha512": "1ad34409b548f366d3e1188323305256e4caa121ee7e753b09eeffe366e459925914b8e60c5d9606956cbd19212827ca0674c16f7a99ac1c0fa45054fcccaf86",
         "dest-filename": "4409b548f366d3e1188323305256e4caa121ee7e753b09eeffe366e459925914b8e60c5d9606956cbd19212827ca0674c16f7a99ac1c0fa45054fcccaf86",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/d3"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-        "sha512": "b72fdf4de929a43d9f23046f9d901575e3a219dd5ced85c48b16e0253373a9cc4958a4278c9fd5d5b344104ea1ca0a4cdd68f01c55152ba1d38d64b35786bcb1",
-        "dest-filename": "df4de929a43d9f23046f9d901575e3a219dd5ced85c48b16e0253373a9cc4958a4278c9fd5d5b344104ea1ca0a4cdd68f01c55152ba1d38d64b35786bcb1",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/2f"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-        "sha512": "02ef6744bf15354badfd74b36d0037f3e33bf1dccfe03f9eaa0de07c91cc2071d86b76e0d3aef18f52b13145a3f9550b6e264ca302a780515b29ccd4acd2759a",
-        "dest-filename": "6744bf15354badfd74b36d0037f3e33bf1dccfe03f9eaa0de07c91cc2071d86b76e0d3aef18f52b13145a3f9550b6e264ca302a780515b29ccd4acd2759a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/ef"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-        "sha512": "9d38ea7dc045122a4a7570afe180d05827e670b64a9bcd65745d29028a53bf2ac51956dc47a3ff54001de46ecdfb4b53afc42a894d2d15a743e852b836d27038",
-        "dest-filename": "ea7dc045122a4a7570afe180d05827e670b64a9bcd65745d29028a53bf2ac51956dc47a3ff54001de46ecdfb4b53afc42a894d2d15a743e852b836d27038",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9d/38"
     },
     {
         "type": "file",
@@ -1291,31 +1200,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-        "sha512": "0fbeae53bdee9525eb0f5517178284d93331555c21b270a07c0c9383d93c3fa2866639572ab38b7b874940a2370718b9c237ac6681572561253560633d931b86",
-        "dest-filename": "ae53bdee9525eb0f5517178284d93331555c21b270a07c0c9383d93c3fa2866639572ab38b7b874940a2370718b9c237ac6681572561253560633d931b86",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/be"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-        "sha512": "ca48b95e72ae7fbe74979d2e193965b7a90a20b6389d0d5e34841ab685c40726797568272aa6e7aa64eb044e41e0dee5acc24a436cad58c8933b6a34bfa130ff",
-        "dest-filename": "b95e72ae7fbe74979d2e193965b7a90a20b6389d0d5e34841ab685c40726797568272aa6e7aa64eb044e41e0dee5acc24a436cad58c8933b6a34bfa130ff",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/48"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
         "sha512": "de5ab3e588d64d89d6e9d9436b94cb69309c4a17daaf57b8d2b99c255c020490ba996945ba3d1e0872049661b5839932b89fc60fef169f814509ccf88093df69",
         "dest-filename": "b3e588d64d89d6e9d9436b94cb69309c4a17daaf57b8d2b99c255c020490ba996945ba3d1e0872049661b5839932b89fc60fef169f814509ccf88093df69",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/5a"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-        "sha512": "2881db2c9aaeef7446aff8676eb3bdb817a2c4d1aebd2423ba5fe3745bd2fca152207d615957759e0ef3387c7e62b11f2272c6eeae27e861d0f5c0edc6ffcfea",
-        "dest-filename": "db2c9aaeef7446aff8676eb3bdb817a2c4d1aebd2423ba5fe3745bd2fca152207d615957759e0ef3387c7e62b11f2272c6eeae27e861d0f5c0edc6ffcfea",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/81"
     },
     {
         "type": "file",
@@ -1333,13 +1221,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-        "sha512": "44e9b308aad39cec326cf709029000e960568a3db71d57c654d2aaaab669bb264e1ea2b60b01d2be91aecadfd434dbda22311df17e48146a78321f887b520725",
-        "dest-filename": "b308aad39cec326cf709029000e960568a3db71d57c654d2aaaab669bb264e1ea2b60b01d2be91aecadfd434dbda22311df17e48146a78321f887b520725",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/e9"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
         "sha512": "897de67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505",
         "dest-filename": "e67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505",
@@ -1347,10 +1228,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
-        "sha512": "353ef0d89554ec316ba0575891eabc732c31ae08cf1d691d5f5c23a514173d7e40b1ec2cded03e1a1b7a95d7503b9324ba67dfa775fb184aa4bb77a98f6b6823",
-        "dest-filename": "f0d89554ec316ba0575891eabc732c31ae08cf1d691d5f5c23a514173d7e40b1ec2cded03e1a1b7a95d7503b9324ba67dfa775fb184aa4bb77a98f6b6823",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/3e"
+        "url": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+        "sha512": "f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
+        "dest-filename": "3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/1d"
     },
     {
         "type": "file",
@@ -1431,24 +1312,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-        "sha512": "6ddd8bebbf2e89601333a9b967557334212b2378e21b3b7a1c663c395202b38d0942afc700b7dbc8d266a745036a4118e2930c68dd0bcb9a26fc1d5523ffb17d",
-        "dest-filename": "8bebbf2e89601333a9b967557334212b2378e21b3b7a1c663c395202b38d0942afc700b7dbc8d266a745036a4118e2930c68dd0bcb9a26fc1d5523ffb17d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/dd"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-        "sha512": "83b9c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af",
-        "dest-filename": "c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/b9"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-        "sha512": "6f0cb43065b9e5b1b8d55ab1c72a4eb1d49d1aa2f05cf23f7e873081360214c6dd522040c4b83d085cc6d3cb33d9aab3927c225fb1e49746d010d8e0f222c1cb",
-        "dest-filename": "b43065b9e5b1b8d55ab1c72a4eb1d49d1aa2f05cf23f7e873081360214c6dd522040c4b83d085cc6d3cb33d9aab3927c225fb1e49746d010d8e0f222c1cb",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/0c"
+        "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+        "sha512": "dd40eff86f42b0228ed5628c1b0f5fc2afd258961b23473963b2d4d405d8a0375b844d801d0e8de8d6f7e2c1bc163ed3e403f2f2a5c308abae207775051d2d54",
+        "dest-filename": "eff86f42b0228ed5628c1b0f5fc2afd258961b23473963b2d4d405d8a0375b844d801d0e8de8d6f7e2c1bc163ed3e403f2f2a5c308abae207775051d2d54",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dd/40"
     },
     {
         "type": "file",
@@ -1466,10 +1333,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz",
-        "sha512": "3685e8e8b8b2da17929254c8e4e2196c28170b5473ac342c664784c1785d3aba37153d5504ebdbb9bbec71d3e78d5b90e00330c2feb5a1a1fde806e2620f449d",
-        "dest-filename": "e8e8b8b2da17929254c8e4e2196c28170b5473ac342c664784c1785d3aba37153d5504ebdbb9bbec71d3e78d5b90e00330c2feb5a1a1fde806e2620f449d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/85"
+        "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.0.12.tgz",
+        "sha512": "e7d0800230214da20c08df32f640f9ef7bc39316ecd6e84372b14b1d282eb5874f706394df945ff79ef6e6c9efcc43b2e01141efe78b27c76308d3e61b01baef",
+        "dest-filename": "800230214da20c08df32f640f9ef7bc39316ecd6e84372b14b1d282eb5874f706394df945ff79ef6e6c9efcc43b2e01141efe78b27c76308d3e61b01baef",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/d0"
     },
     {
         "type": "file",
@@ -1487,17 +1354,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.6.tgz",
-        "sha512": "f0d1e2ef7a2da56b19181499c309274d74b9a6a30eae4f7e4acae76bcc426b193312953d3937fd47902b406570d37fff66693d30ec0b3e783d5b09ddbe9009e6",
-        "dest-filename": "e2ef7a2da56b19181499c309274d74b9a6a30eae4f7e4acae76bcc426b193312953d3937fd47902b406570d37fff66693d30ec0b3e783d5b09ddbe9009e6",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/d1"
+        "url": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+        "sha512": "cc81f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478",
+        "dest-filename": "f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/81"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-        "sha512": "66674bdabba2f9e07663086c5b38c89d1f0b95db591c60e8435ba01fce69a472b0a541cbee3eeb3744e2f4d0a71a241b85a675d45a51fbb6a8d5d36c99db8d52",
-        "dest-filename": "4bdabba2f9e07663086c5b38c89d1f0b95db591c60e8435ba01fce69a472b0a541cbee3eeb3744e2f4d0a71a241b85a675d45a51fbb6a8d5d36c99db8d52",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/66/67"
+        "url": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+        "sha512": "9bf0be030380afdfd6d54388654a36df67a330d9c9009b5842351b1e835304d4c94afab3cc387bbe7ade8b7a37af79bd6e57fa6680e4bdcc34566a33351149c6",
+        "dest-filename": "be030380afdfd6d54388654a36df67a330d9c9009b5842351b1e835304d4c94afab3cc387bbe7ade8b7a37af79bd6e57fa6680e4bdcc34566a33351149c6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/f0"
     },
     {
         "type": "file",
@@ -1515,13 +1382,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-        "sha512": "58cc26f4b851528f9651a44dfaf46e113a86f3d22066985548d91d16079beac4bf1383ab0c837bb78f0201ec121d773a0bc95e7c3f0a29faf9bd8eb56eb425a3",
-        "dest-filename": "26f4b851528f9651a44dfaf46e113a86f3d22066985548d91d16079beac4bf1383ab0c837bb78f0201ec121d773a0bc95e7c3f0a29faf9bd8eb56eb425a3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/58/cc"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
         "sha512": "51e26615f3ab0104bc38958f678aad807c961316b4f3cfccb4ae54132a091851faedc0c45e4652be23a2291099e178a3d33c48dc9102818b37a0ac7e022cd004",
         "dest-filename": "6615f3ab0104bc38958f678aad807c961316b4f3cfccb4ae54132a091851faedc0c45e4652be23a2291099e178a3d33c48dc9102818b37a0ac7e022cd004",
@@ -1529,24 +1389,24 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz",
-        "sha512": "da7b6427ef7ed0614fea70084a231a6cab7a7aa041d245f542a1cd5855805e08b45542ca1a2b0ce3a96e445a48062537bbf4c39a164c33cb73be8d806e7ddaca",
-        "dest-filename": "6427ef7ed0614fea70084a231a6cab7a7aa041d245f542a1cd5855805e08b45542ca1a2b0ce3a96e445a48062537bbf4c39a164c33cb73be8d806e7ddaca",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/7b"
+        "url": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.12.tgz",
+        "sha512": "929c1733b73f6b24546d8544ad06ec6749d0657e1a2c742b3c41bd0b887dbee2425f2970147f1aec9822d95a4a20e6f30973bb2ca1e20b0e0a762a052c53a0a8",
+        "dest-filename": "1733b73f6b24546d8544ad06ec6749d0657e1a2c742b3c41bd0b887dbee2425f2970147f1aec9822d95a4a20e6f30973bb2ca1e20b0e0a762a052c53a0a8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/9c"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz",
-        "sha512": "a6846002d5071ce9e5cd99dcf4f2b89f31b9df187be308f6272ee3913aea6743163e81c6875336f82fff846798740fb82bcc38ca2542358a0b5c5ef24a3d968a",
-        "dest-filename": "6002d5071ce9e5cd99dcf4f2b89f31b9df187be308f6272ee3913aea6743163e81c6875336f82fff846798740fb82bcc38ca2542358a0b5c5ef24a3d968a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/84"
+        "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.0.12.tgz",
+        "sha512": "703d64cf9836b203d33051e32f17cc8d42b924006adfffc9e233ecc22f77b4e3c5cfa6edcd762d2b936b0edef5ecd45bba40940ceaebbe661539611196aa225c",
+        "dest-filename": "64cf9836b203d33051e32f17cc8d42b924006adfffc9e233ecc22f77b4e3c5cfa6edcd762d2b936b0edef5ecd45bba40940ceaebbe661539611196aa225c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/3d"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
-        "sha512": "fa36d3911f66dfd78304c3f881f6ea8250dde94bc10bb44b879634321152b1ce949061e3f558fd4d6a1bc5ebc760c32a9a8ba32f5d592e37cfa4c5fe3ede9812",
-        "dest-filename": "d3911f66dfd78304c3f881f6ea8250dde94bc10bb44b879634321152b1ce949061e3f558fd4d6a1bc5ebc760c32a9a8ba32f5d592e37cfa4c5fe3ede9812",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/36"
+        "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.0.11.tgz",
+        "sha512": "6bc4111f4ac03c8587f56cb24b92db36f5bd02b93aa9eeb7fcba8307bbeed895d8a62d0699ae50eb40e1e2d993aa138142dd31b2bcc3f2a13b0be0fb8fe076e0",
+        "dest-filename": "111f4ac03c8587f56cb24b92db36f5bd02b93aa9eeb7fcba8307bbeed895d8a62d0699ae50eb40e1e2d993aa138142dd31b2bcc3f2a13b0be0fb8fe076e0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/c4"
     },
     {
         "type": "file",
@@ -1557,10 +1417,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.3.9.tgz",
-        "sha512": "d8f24d38d8be88189d9280b90f59f34fd5eab04f10d57dbc167eb145084edd85fca914722779a4578175690b2e46760faaae87c3e139d72dbb5bbe56803a287f",
-        "dest-filename": "4d38d8be88189d9280b90f59f34fd5eab04f10d57dbc167eb145084edd85fca914722779a4578175690b2e46760faaae87c3e139d72dbb5bbe56803a287f",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d8/f2"
+        "url": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz",
+        "sha512": "0abe060ce91b014a911cfe7fa1e3a61ff2f6067ebe1503f154b66d3db7262990baddad45deebb911e7d83acb206571b7bbfcc196e6db2793c97484dd3158206f",
+        "dest-filename": "060ce91b014a911cfe7fa1e3a61ff2f6067ebe1503f154b66d3db7262990baddad45deebb911e7d83acb206571b7bbfcc196e6db2793c97484dd3158206f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0a/be"
     },
     {
         "type": "file",
@@ -1571,10 +1431,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron/-/electron-36.2.0.tgz",
-        "sha512": "e7295da118c12b13d07c8d10317faaabbe74a37365f0dd5266726a38f32ad2067aac827eef2e192e9f34f06ac5c237d39b4e53620ab71920fc146b8a419ab013",
-        "dest-filename": "5da118c12b13d07c8d10317faaabbe74a37365f0dd5266726a38f32ad2067aac827eef2e192e9f34f06ac5c237d39b4e53620ab71920fc146b8a419ab013",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/29"
+        "url": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+        "sha512": "6cedf2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be",
+        "dest-filename": "f2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/ed"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron/-/electron-36.2.1.tgz",
+        "sha512": "9a6d58f8cb38eb170e4c0ebd87c869a9f5f7f761df5789606bd68491891dfd2cb1d49052b6f70008e228b82806ae7669c4d64f552d6333c35370c90d8ee2ba05",
+        "dest-filename": "58f8cb38eb170e4c0ebd87c869a9f5f7f761df5789606bd68491891dfd2cb1d49052b6f70008e228b82806ae7669c4d64f552d6333c35370c90d8ee2ba05",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/6d"
     },
     {
         "type": "file",
@@ -1596,13 +1463,6 @@
         "sha512": "2f5f03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca",
         "dest-filename": "03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/5f"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-        "sha512": "4349fd1d18b89ba26e188575785966bc907b644571bbddc8accca232c182d25acc24c5b3460c7a586aaec9f4206556f7d6f8468179df98f34d5e6c673a4441ae",
-        "dest-filename": "fd1d18b89ba26e188575785966bc907b644571bbddc8accca232c182d25acc24c5b3460c7a586aaec9f4206556f7d6f8468179df98f34d5e6c673a4441ae",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/49"
     },
     {
         "type": "file",
@@ -1669,6 +1529,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+        "sha512": "8fabd6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+        "dest-filename": "d6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/ab"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
         "sha512": "526ffe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
         "dest-filename": "fe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
@@ -1680,13 +1547,6 @@
         "sha512": "5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
         "dest-filename": "f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/48"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "sha512": "3624aea59e0e7ae1b0afaf251887b29bf92c219309a1d506392099fc54a74f172b7a46efaab81d53194938ca628da299563009ad6ac6b3fe89cbc38cbb28fda3",
-        "dest-filename": "aea59e0e7ae1b0afaf251887b29bf92c219309a1d506392099fc54a74f172b7a46efaab81d53194938ca628da299563009ad6ac6b3fe89cbc38cbb28fda3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/24"
     },
     {
         "type": "file",
@@ -1718,10 +1578,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
-        "sha512": "1f1d0c3a33e1eae2bda2af6756c01364a13f5a56da8bb2858df0aec3d5076a0b835b7c7e1c5d0ee67222dee777f535a0ad38d33b99c7c662f74757803629d61d",
-        "dest-filename": "0c3a33e1eae2bda2af6756c01364a13f5a56da8bb2858df0aec3d5076a0b835b7c7e1c5d0ee67222dee777f535a0ad38d33b99c7c662f74757803629d61d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/1d"
+        "url": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
+        "sha512": "8b145ac0542e301f4367b7e35378861a06a7143a77fb8e5b3ce75a46eadc1474973b57bfb18c145ff16d419a4b64947a4a3328247f21476a4f1007c3c82a14d9",
+        "dest-filename": "5ac0542e301f4367b7e35378861a06a7143a77fb8e5b3ce75a46eadc1474973b57bfb18c145ff16d419a4b64947a4a3328247f21476a4f1007c3c82a14d9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/14"
     },
     {
         "type": "file",
@@ -1760,13 +1620,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-        "sha512": "6882f9171ee66b055adf4d1a976067104e2236fa35a844f12eb3c8fe8d392fbcfa828edf0b0d49e844266cae05989d804bb920545fca1195ae7c17dd0a531c3e",
-        "dest-filename": "f9171ee66b055adf4d1a976067104e2236fa35a844f12eb3c8fe8d392fbcfa828edf0b0d49e844266cae05989d804bb920545fca1195ae7c17dd0a531c3e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/82"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
         "sha512": "196901be389264af3b10bad839211251879521cf66bcb2dffe75da94c392e5d62b819abda3939591b64054cd3a095c58b02c07f410d914f9504e53c0d63e1a84",
         "dest-filename": "01be389264af3b10bad839211251879521cf66bcb2dffe75da94c392e5d62b819abda3939591b64054cd3a095c58b02c07f410d914f9504e53c0d63e1a84",
@@ -1774,45 +1627,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-        "sha512": "54045327d0987ae4186f4a5910f6f38bbe34396160a477bb0182765856559d40d4429e43936c89520177e98b19f3570ecb14f44319970f6110a5aa40a2ecd654",
-        "dest-filename": "5327d0987ae4186f4a5910f6f38bbe34396160a477bb0182765856559d40d4429e43936c89520177e98b19f3570ecb14f44319970f6110a5aa40a2ecd654",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/04"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
-        "sha512": "975f56a44da6f614aec8fd3af856ee5147f51be4744852ebb507db45bf4f46bfa88a639fc508601826d569783922f672c934e126cc61e8bfecae432209e04f0c",
-        "dest-filename": "56a44da6f614aec8fd3af856ee5147f51be4744852ebb507db45bf4f46bfa88a639fc508601826d569783922f672c934e126cc61e8bfecae432209e04f0c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/5f"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-        "sha512": "57286779b5dc8855760c449cfa9e81fb2d0b8d29b492b5383a024de38a85021058d1327ed55eb5b580f6fb01eeb19e85f67e4afaf97c934b13cbb3c47d5e2aa6",
-        "dest-filename": "6779b5dc8855760c449cfa9e81fb2d0b8d29b492b5383a024de38a85021058d1327ed55eb5b580f6fb01eeb19e85f67e4afaf97c934b13cbb3c47d5e2aa6",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/28"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
-        "sha512": "757edefcb1d527a5b70c4d4c1d68bd4b5118cc311210d7cbad8a211b61befa8bd9ad83a49b82a7c1ad26735727f38c49391e0a114d1649c8612db77452495b1f",
-        "dest-filename": "defcb1d527a5b70c4d4c1d68bd4b5118cc311210d7cbad8a211b61befa8bd9ad83a49b82a7c1ad26735727f38c49391e0a114d1649c8612db77452495b1f",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/7e"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-        "sha512": "781e736d087987e55e9cc3ccddf87e9f0d581318b99ccafa1d4091eb610b48fd7586ebf19bf522af51f5404c93924e505fa039f295fa36669331c78a67412876",
-        "dest-filename": "736d087987e55e9cc3ccddf87e9f0d581318b99ccafa1d4091eb610b48fd7586ebf19bf522af51f5404c93924e505fa039f295fa36669331c78a67412876",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/78/1e"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-        "sha512": "0d3f5c939608454fbc198cf3539913dde1c603988bfb565dd04bad3a64c4f43b64f93beecdddb754153e79cec73cd493c5760ee7980f57f86ae294812438c5a4",
-        "dest-filename": "5c939608454fbc198cf3539913dde1c603988bfb565dd04bad3a64c4f43b64f93beecdddb754153e79cec73cd493c5760ee7980f57f86ae294812438c5a4",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/3f"
+        "url": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+        "sha512": "f10c584d55d492ecbb7c82288ad4243f01a89c1f05dd98fc7843bc4aa83d66ffdb908ed1240ce8c1e7b882bf351da93f7544e903667b55f420a228e33cd95464",
+        "dest-filename": "584d55d492ecbb7c82288ad4243f01a89c1f05dd98fc7843bc4aa83d66ffdb908ed1240ce8c1e7b882bf351da93f7544e903667b55f420a228e33cd95464",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/0c"
     },
     {
         "type": "file",
@@ -1900,13 +1718,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-        "sha512": "fedf3c4f2ddde495906d662068e1820987d7470575f9b7b4d96a986252fa87494489400c3ccf28f2a2863b4d58224387ce46b6ba9d3cc2f8180f4983888faadd",
-        "dest-filename": "3c4f2ddde495906d662068e1820987d7470575f9b7b4d96a986252fa87494489400c3ccf28f2a2863b4d58224387ce46b6ba9d3cc2f8180f4983888faadd",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/df"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
         "sha512": "efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
         "dest-filename": "cf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
@@ -1935,38 +1746,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-        "sha512": "2ddda0f2bac0c8c6055c1844a8ccfc6401c18b8278b92d62fc2c463039e3c8559d74c5cb55c0e9d39d4365fbbeb7bf9a6fb5afe9232aa569b21488f951b7c5be",
-        "dest-filename": "a0f2bac0c8c6055c1844a8ccfc6401c18b8278b92d62fc2c463039e3c8559d74c5cb55c0e9d39d4365fbbeb7bf9a6fb5afe9232aa569b21488f951b7c5be",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/dd"
+        "url": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+        "sha512": "8085e32aab45b96120cc544903d58241e4892d90e380950e302333c6dbc5abfdfb2a88ccd41146b9faac0b2d2be2a4909982ec65831ec91ab321638cba9d37b3",
+        "dest-filename": "e32aab45b96120cc544903d58241e4892d90e380950e302333c6dbc5abfdfb2a88ccd41146b9faac0b2d2be2a4909982ec65831ec91ab321638cba9d37b3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/85"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-        "sha512": "b7337c7b84d7f3e924c463caf03e6ed053668cf523c379700bd9522f1c6807ff86b6c246f7508ef1b496cbbdc03e580067365b5c461926ec639071f6c3e13387",
-        "dest-filename": "7c7b84d7f3e924c463caf03e6ed053668cf523c379700bd9522f1c6807ff86b6c246f7508ef1b496cbbdc03e580067365b5c461926ec639071f6c3e13387",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/33"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-        "sha512": "6ee446d1fa41b511d24c238049eea10f6e7cb44b9b16844b6f864d03a3713151cdc3680e7301e8f70c9a6e5ccccce039cfdc40f4bd4a36393f36de8c4fd698a3",
-        "dest-filename": "46d1fa41b511d24c238049eea10f6e7cb44b9b16844b6f864d03a3713151cdc3680e7301e8f70c9a6e5ccccce039cfdc40f4bd4a36393f36de8c4fd698a3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/e4"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-        "sha512": "471fd6c9c67ad0739aa8b2808ba70744a288ef3c566c9df53219ed9adc0ca1a4de17b5c51fd861069f2f21368c89d7e58d143a7985822a46932beca45491cfd8",
-        "dest-filename": "d6c9c67ad0739aa8b2808ba70744a288ef3c566c9df53219ed9adc0ca1a4de17b5c51fd861069f2f21368c89d7e58d143a7985822a46932beca45491cfd8",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/1f"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-        "sha512": "cba380c284887fb1728cc22ff78bbe6f9add85e6448f347adc64f26499b9aa1e018bed988302c2708fdf3c56642f93d28b13ade9934a9bec3e1dfa7f05c8b0a3",
-        "dest-filename": "80c284887fb1728cc22ff78bbe6f9add85e6448f347adc64f26499b9aa1e018bed988302c2708fdf3c56642f93d28b13ade9934a9bec3e1dfa7f05c8b0a3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cb/a3"
+        "url": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+        "sha512": "8467e6fec96ed1969b9cdb78a1a459eae444c9f0a3e8fe1f4ff9fa035ac657e67455d1978df3a1554a649faa9540e3471881709af7865f20ecef9fa7afa14cf3",
+        "dest-filename": "e6fec96ed1969b9cdb78a1a459eae444c9f0a3e8fe1f4ff9fa035ac657e67455d1978df3a1554a649faa9540e3471881709af7865f20ecef9fa7afa14cf3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/84/67"
     },
     {
         "type": "file",
@@ -1977,10 +1767,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-        "sha512": "3e60e2deec0ae6716e5e1ed70d39559d2d7bc494bbbd6dfa8acdbec37c5cbfc495c620783720137f872d9156396e44a35f46389dbbd90aad7f123b44cabf64b7",
-        "dest-filename": "e2deec0ae6716e5e1ed70d39559d2d7bc494bbbd6dfa8acdbec37c5cbfc495c620783720137f872d9156396e44a35f46389dbbd90aad7f123b44cabf64b7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3e/60"
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+        "sha512": "6785da08be9d5031df3ff8d3db98c928c9adc6fbb06e4ac3d6f352305968f6534b6367391476124201cf459523001dba4e90c4a16f4708e82996b75b68f57f7b",
+        "dest-filename": "da08be9d5031df3ff8d3db98c928c9adc6fbb06e4ac3d6f352305968f6534b6367391476124201cf459523001dba4e90c4a16f4708e82996b75b68f57f7b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/85"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+        "sha512": "6090da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b",
+        "dest-filename": "da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/90"
     },
     {
         "type": "file",
@@ -2019,13 +1816,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-        "sha512": "7fd9be0443798e483a6b47d98e57a2763379d551355fe98f150d83274bafd55dfda022c26ec19eeb28db067a7b78aef3ffe180a27f7d6b79c7baa6eebad8723e",
-        "dest-filename": "be0443798e483a6b47d98e57a2763379d551355fe98f150d83274bafd55dfda022c26ec19eeb28db067a7b78aef3ffe180a27f7d6b79c7baa6eebad8723e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/d9"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
         "sha512": "0f214fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
         "dest-filename": "4fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
@@ -2058,13 +1848,6 @@
         "sha512": "9c117e175ac06550aefe9eeb8f3800f986f895f617ae997b6ba56626b53cc05f48d422af3ff4303cd6479ce9706d3918e9dbed148cc5312c905db2e84d03d1a4",
         "dest-filename": "7e175ac06550aefe9eeb8f3800f986f895f617ae997b6ba56626b53cc05f48d422af3ff4303cd6479ce9706d3918e9dbed148cc5312c905db2e84d03d1a4",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/11"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-        "sha512": "55a509b2905f7e7fcb302255a0cbd201d9ac709c92d5aba3e59ba59e7e54a18718e77d545a67708515a47062a7194f779b91d25cff4b3f6bac3abcab06d428c0",
-        "dest-filename": "09b2905f7e7fcb302255a0cbd201d9ac709c92d5aba3e59ba59e7e54a18718e77d545a67708515a47062a7194f779b91d25cff4b3f6bac3abcab06d428c0",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/a5"
     },
     {
         "type": "file",
@@ -2194,10 +1977,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-        "sha512": "f117fd63cdcd05178c9f1d2017303c248990002b2d098594a657a90daf71a6bc30b6680465417487f8b9c5203adb9cc1fc8dfb12daecc12493e8e5f1c1a68825",
-        "dest-filename": "fd63cdcd05178c9f1d2017303c248990002b2d098594a657a90daf71a6bc30b6680465417487f8b9c5203adb9cc1fc8dfb12daecc12493e8e5f1c1a68825",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/17"
+        "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+        "sha512": "36a00307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+        "dest-filename": "0307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/a0"
     },
     {
         "type": "file",
@@ -2219,13 +2002,6 @@
         "sha512": "7abdbde4328f56c57cda3e64c351a3b7e00303f5d81ec6a397cd9c18d406d9eca83e4be05215fe9c32327a5ce12166dbb173f7f441dc23a979b58b36158a985d",
         "dest-filename": "bde4328f56c57cda3e64c351a3b7e00303f5d81ec6a397cd9c18d406d9eca83e4be05215fe9c32327a5ce12166dbb173f7f441dc23a979b58b36158a985d",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/bd"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-        "sha512": "16dc2b1bf7ae0736848d8791a8e825cbb1b4aaf8a25e82569ef107d99d6994175781bca3bf7e291d349bf73a1e1ccc83cb7dfe0d6cb95adf56a3e4d446d39849",
-        "dest-filename": "2b1bf7ae0736848d8791a8e825cbb1b4aaf8a25e82569ef107d99d6994175781bca3bf7e291d349bf73a1e1ccc83cb7dfe0d6cb95adf56a3e4d446d39849",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/dc"
     },
     {
         "type": "file",
@@ -2257,17 +2033,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-        "sha512": "d5ee16a9e6e57abcfeb4c28f22ad843068a2596d5d22364e92cc87592526d6b9aebf0fe1a30f61047677f250068f9203e0893a11d90ec3b36658fcba2c0c1a97",
-        "dest-filename": "16a9e6e57abcfeb4c28f22ad843068a2596d5d22364e92cc87592526d6b9aebf0fe1a30f61047677f250068f9203e0893a11d90ec3b36658fcba2c0c1a97",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/ee"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-        "sha512": "0177196fabf3ceb140504eb51e73789a92ea77f7122303508ed3564747ae3e6eb2d22ab1dc6e203976880ddb5d0f06668707bcd8b03afb38a7996e1405655e3d",
-        "dest-filename": "196fabf3ceb140504eb51e73789a92ea77f7122303508ed3564747ae3e6eb2d22ab1dc6e203976880ddb5d0f06668707bcd8b03afb38a7996e1405655e3d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/01/77"
+        "url": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+        "sha512": "bcaf4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+        "dest-filename": "4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/af"
     },
     {
         "type": "file",
@@ -2303,6 +2072,13 @@
         "sha512": "86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
         "dest-filename": "53354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+        "sha512": "809cf393e3d03739f3f32b11ac2d1a3a404d551043b44d67e7722acaa11fdcf5eb630a2616ce6ae2918c8b304c245fb2921d378a7b09dbb841f204ab0f61e7f0",
+        "dest-filename": "f393e3d03739f3f32b11ac2d1a3a404d551043b44d67e7722acaa11fdcf5eb630a2616ce6ae2918c8b304c245fb2921d378a7b09dbb841f204ab0f61e7f0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/9c"
     },
     {
         "type": "file",
@@ -2366,13 +2142,6 @@
         "sha512": "cc7b50cc6a236574f06531d0aab6be11329de129f7be08bbb819a53e85d5599a98bee2a6b48d25fd56538ea1a6258f71f3c18639a67df86f444bc842e13e17f2",
         "dest-filename": "50cc6a236574f06531d0aab6be11329de129f7be08bbb819a53e85d5599a98bee2a6b48d25fd56538ea1a6258f71f3c18639a67df86f444bc842e13e17f2",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/7b"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-        "sha512": "d0a23feb4ef1a31493a07ec68cdd457d26cba14d3e6ed4e2723b1049642587f859ca437c2a998c7fbb98c0f5b747e6a467a47fc35f199574870585e26143cede",
-        "dest-filename": "3feb4ef1a31493a07ec68cdd457d26cba14d3e6ed4e2723b1049642587f859ca437c2a998c7fbb98c0f5b747e6a467a47fc35f199574870585e26143cede",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/a2"
     },
     {
         "type": "file",
@@ -2453,20 +2222,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-        "sha512": "86fa6823a928ae124c9de8f6f3975283a9eed7e7babb1b3bcc6dc16009b96f2a83b2024d5b0c7333acfa8998808104784c9df42660533b0a99530dd69721f701",
-        "dest-filename": "6823a928ae124c9de8f6f3975283a9eed7e7babb1b3bcc6dc16009b96f2a83b2024d5b0c7333acfa8998808104784c9df42660533b0a99530dd69721f701",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/fa"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-        "sha512": "2e7411e1b67d2000c345292fa6a306bedfed10959c9739253604b0e3c57910068078377aa86bcdf1e8ba939a74b6fc52475ef55661b21ee4e200e7f101bafc90",
-        "dest-filename": "11e1b67d2000c345292fa6a306bedfed10959c9739253604b0e3c57910068078377aa86bcdf1e8ba939a74b6fc52475ef55661b21ee4e200e7f101bafc90",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2e/74"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
         "sha512": "fa80d396e47a5848dd5c424c9c2db3e80e0547016862ebd28555441ac4bb7b07345138b642d00a30326e2f8043115b7ee53ecc8c5a35d913fc82138cef9a0a27",
         "dest-filename": "d396e47a5848dd5c424c9c2db3e80e0547016862ebd28555441ac4bb7b07345138b642d00a30326e2f8043115b7ee53ecc8c5a35d913fc82138cef9a0a27",
@@ -2478,13 +2233,6 @@
         "sha512": "927c46daae140b7bbcb2d446c8054908e771166bf90d989171d94868041701b49f2726be3a1a29368b4b42bb2d061aaeaaee19a6e29b0dcffc4ba9a05e03c53f",
         "dest-filename": "46daae140b7bbcb2d446c8054908e771166bf90d989171d94868041701b49f2726be3a1a29368b4b42bb2d061aaeaaee19a6e29b0dcffc4ba9a05e03c53f",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/7c"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-        "sha512": "54b82121634ce842d0ce8ef3c26720d0d99357258a623bc878cf37ca3a74c110d39949eb33aefc7d06dc281a3a9f6089105d2cce81bfff2b60f932a56bcf402d",
-        "dest-filename": "2121634ce842d0ce8ef3c26720d0d99357258a623bc878cf37ca3a74c110d39949eb33aefc7d06dc281a3a9f6089105d2cce81bfff2b60f932a56bcf402d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/b8"
     },
     {
         "type": "file",
@@ -2635,13 +2383,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-        "sha512": "6fde0688d1d0372e89353aede70eb33727df32b3645d96f72939026496f6575c5a1060a4d3ddef919da3937b6969e3f7dff3a25c2f96bcaf40c5479b9dfe676f",
-        "dest-filename": "0688d1d0372e89353aede70eb33727df32b3645d96f72939026496f6575c5a1060a4d3ddef919da3937b6969e3f7dff3a25c2f96bcaf40c5479b9dfe676f",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/de"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
         "sha512": "f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
         "dest-filename": "f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
@@ -2663,17 +2404,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
-        "sha512": "61448e2eaf55791340a3f0936959a1183286f8b06d03c285d57e0ae7eca4312c16493d6f0f125107692fd823a02dbd5fbe90a8f80ff2f40d06d339cd566771e3",
-        "dest-filename": "8e2eaf55791340a3f0936959a1183286f8b06d03c285d57e0ae7eca4312c16493d6f0f125107692fd823a02dbd5fbe90a8f80ff2f40d06d339cd566771e3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/44"
+        "url": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.0.0.tgz",
+        "sha512": "b140a9ade3ecebfadbc78bca0bad077b3e97d741cf9290c9686732dc3d4d77047b83545c36458bf2af6624cade3aa987053b3ed6c345a7ec0e897f5fafe86839",
+        "dest-filename": "a9ade3ecebfadbc78bca0bad077b3e97d741cf9290c9686732dc3d4d77047b83545c36458bf2af6624cade3aa987053b3ed6c345a7ec0e897f5fafe86839",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/40"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/listr2/-/listr2-8.2.5.tgz",
-        "sha512": "8b201909ec83f9cd603f213daa916ef1a7f463e311b6628e9dc746a00d92e4463c885abdf5d9a6be43671e25a8fa98f4b3bc87ee5dca3c881e7bbeed2a95cf59",
-        "dest-filename": "1909ec83f9cd603f213daa916ef1a7f463e311b6628e9dc746a00d92e4463c885abdf5d9a6be43671e25a8fa98f4b3bc87ee5dca3c881e7bbeed2a95cf59",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/20"
+        "url": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+        "sha512": "2d6cd7d8ab2a701d70a90e001e061be11b035dab908aa8632e4fba8636da7871b8ce98e354007ac02fe0cfa5f497e0eed5c377a54079665aef4db84648d9d441",
+        "dest-filename": "d7d8ab2a701d70a90e001e061be11b035dab908aa8632e4fba8636da7871b8ce98e354007ac02fe0cfa5f497e0eed5c377a54079665aef4db84648d9d441",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/6c"
     },
     {
         "type": "file",
@@ -2719,31 +2460,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-        "sha512": "aa3c4f2c7777af90e7b1d19a72a38c53aa5bfdabc9cdd87db455f6ca6828644dbb0668d7acdcbfcb82e86a24de01bf8ede02fc01fa491ada9f5ff69eda579861",
-        "dest-filename": "4f2c7777af90e7b1d19a72a38c53aa5bfdabc9cdd87db455f6ca6828644dbb0668d7acdcbfcb82e86a24de01bf8ede02fc01fa491ada9f5ff69eda579861",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/3c"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-        "sha512": "752da3f96dba4d0eed69004637c2db6ead38b2c5777a6470e0d639f1612b9533b6f6922a4b41e6a13e5a27df93510d4ddc6f893994a38b87ae82c5b01a9f723c",
-        "dest-filename": "a3f96dba4d0eed69004637c2db6ead38b2c5777a6470e0d639f1612b9533b6f6922a4b41e6a13e5a27df93510d4ddc6f893994a38b87ae82c5b01a9f723c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/2d"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
         "sha512": "4ccf5806fc82f38671137ae07de7f151689028b8a5b2d0fa93b3d31adeb07dbb5717c8b12092ce2f7558c95ff3f9988f2ec57102c280155c1695679bd98f18cb",
         "dest-filename": "5806fc82f38671137ae07de7f151689028b8a5b2d0fa93b3d31adeb07dbb5717c8b12092ce2f7558c95ff3f9988f2ec57102c280155c1695679bd98f18cb",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4c/cf"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-        "sha512": "0b93766770e09e72abd0b3a9bff84a0a029d6fb659c1a7c8aec7acbdeea59b3bd921165119a67f97a43cfb65bb35a4fe6703b77c59520b30b3ac30857497d9e2",
-        "dest-filename": "766770e09e72abd0b3a9bff84a0a029d6fb659c1a7c8aec7acbdeea59b3bd921165119a67f97a43cfb65bb35a4fe6703b77c59520b30b3ac30857497d9e2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/93"
     },
     {
         "type": "file",
@@ -2793,13 +2513,6 @@
         "sha512": "f962aab0adbde073127368c46cd8291e977425f201869eeb115e1aa975aa16be80957a2ff9295c801d45bf4d72da419edc673c9cc5bb540d12ac6b929117c812",
         "dest-filename": "aab0adbde073127368c46cd8291e977425f201869eeb115e1aa975aa16be80957a2ff9295c801d45bf4d72da419edc673c9cc5bb540d12ac6b929117c812",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/62"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-        "sha512": "738a41d82746ac676330a60b03e5e24433bb6343d141b9bf1b383ca8c8fe407fa91550284e9e6c0693b4a1d2f7163a0f0868caf7aa7aaac3fec90a222e838173",
-        "dest-filename": "41d82746ac676330a60b03e5e24433bb6343d141b9bf1b383ca8c8fe407fa91550284e9e6c0693b4a1d2f7163a0f0868caf7aa7aaac3fec90a222e838173",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/8a"
     },
     {
         "type": "file",
@@ -2866,10 +2579,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/lucide-static/-/lucide-static-0.508.0.tgz",
-        "sha512": "61f9536e1961b43c60c68ff8744389df74db05805375181529d2fbe55a67e299b6907344f7a655e2d1df373d3eda22f8488e136be112d89f9da41757e54b4dfe",
-        "dest-filename": "536e1961b43c60c68ff8744389df74db05805375181529d2fbe55a67e299b6907344f7a655e2d1df373d3eda22f8488e136be112d89f9da41757e54b4dfe",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/f9"
+        "url": "https://registry.npmjs.org/lucide-static/-/lucide-static-0.511.0.tgz",
+        "sha512": "fcc58e8c4c8664ef38075e817aa6de95e8a76e6798c4e06c6d80edfd893ac46c0c6300e6e9dc78de3287331183a96f54f38a962f5ddd36f556d123000e1512ca",
+        "dest-filename": "8e8c4c8664ef38075e817aa6de95e8a76e6798c4e06c6d80edfd893ac46c0c6300e6e9dc78de3287331183a96f54f38a962f5ddd36f556d123000e1512ca",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/c5"
     },
     {
         "type": "file",
@@ -2894,31 +2607,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-        "sha512": "6a2b27ac33f818d7b4e9470a1675796df30d3c1530e23b0b19a5b059f9c7defd361a706e5d7d8c0959f945bad6a348f7a5ccd48a561b96aedf43b370dade572b",
-        "dest-filename": "27ac33f818d7b4e9470a1675796df30d3c1530e23b0b19a5b059f9c7defd361a706e5d7d8c0959f945bad6a348f7a5ccd48a561b96aedf43b370dade572b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/2b"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
         "sha512": "0615ccd00bb6d91c149de30fc120a7ca14ce8b3756a0810f53db29d00a9ad4f9c3311e56bf61465d80e3bb3244217f84a3645bf31b987b98eb9e6e50a3040593",
         "dest-filename": "ccd00bb6d91c149de30fc120a7ca14ce8b3756a0810f53db29d00a9ad4f9c3311e56bf61465d80e3bb3244217f84a3645bf31b987b98eb9e6e50a3040593",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/15"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-        "sha512": "4a7937d785796b214b869ddf914444b9be96b6305f3dd08f6352e7f3ff26ba7b8bba2621b000600555aca33006f8c58c6d512f71d7296e2f51ef0c36da5f50de",
-        "dest-filename": "37d785796b214b869ddf914444b9be96b6305f3dd08f6352e7f3ff26ba7b8bba2621b000600555aca33006f8c58c6d512f71d7296e2f51ef0c36da5f50de",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/79"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-        "sha512": "69bbffa8e72e3df9375113df0f39995352ca9aec3c913fb49c81ef2ab2a016bc227e897f76859c740e19aac590f0436b14a91debb31fa68fcba2f6c852c6eddf",
-        "dest-filename": "ffa8e72e3df9375113df0f39995352ca9aec3c913fb49c81ef2ab2a016bc227e897f76859c740e19aac590f0436b14a91debb31fa68fcba2f6c852c6eddf",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/bb"
     },
     {
         "type": "file",
@@ -2943,24 +2635,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-        "sha512": "694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d",
-        "dest-filename": "4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/4e"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
         "sha512": "64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
         "dest-filename": "3e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/36"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-        "sha512": "c51738a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758",
-        "dest-filename": "38a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/17"
     },
     {
         "type": "file",
@@ -2975,13 +2653,6 @@
         "sha512": "3aa6ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672",
         "dest-filename": "ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/a6"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-        "sha512": "bea882d3a0ae8414d47591fe45897cb05acbd3deaf038e4e9392123bab04fccaf58d16c61f80ac9e18bc7f7c0a565ef1f263b802eec8afd0f73b2bf555830527",
-        "dest-filename": "82d3a0ae8414d47591fe45897cb05acbd3deaf038e4e9392123bab04fccaf58d16c61f80ac9e18bc7f7c0a565ef1f263b802eec8afd0f73b2bf555830527",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/a8"
     },
     {
         "type": "file",
@@ -3125,6 +2796,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.1.tgz",
+        "sha512": "05f72fcc19544f148359f4fea07eef77a09b515fab4e12cb1c22329bf40ee8618b06cc955e5799b34d1fb68da2da3cc2ff03e20589398f23a6a575a0e18a2988",
+        "dest-filename": "2fcc19544f148359f4fea07eef77a09b515fab4e12cb1c22329bf40ee8618b06cc955e5799b34d1fb68da2da3cc2ff03e20589398f23a6a575a0e18a2988",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/f7"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
         "sha512": "396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b",
         "dest-filename": "43f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b",
@@ -3139,17 +2817,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-        "sha512": "f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a",
-        "dest-filename": "ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/e7"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
-        "sha512": "499e34bd18b2ffec114dfdb58719241233c9669011cd4315709a10b1ed8417caa45166db3b6cfbbdde6803f1fa6d51fa49943949319cbb42910d2edb88d45fc7",
-        "dest-filename": "34bd18b2ffec114dfdb58719241233c9669011cd4315709a10b1ed8417caa45166db3b6cfbbdde6803f1fa6d51fa49943949319cbb42910d2edb88d45fc7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/9e"
+        "url": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+        "sha512": "3a161a639b03b0891aec7ec0b628ed23d8f01982f2976f5e427fd6eb6dc388dfcc22fe6c52a73883b0480d3857fa06fb762f5feb12b4da7929f2c75f15664b4e",
+        "dest-filename": "1a639b03b0891aec7ec0b628ed23d8f01982f2976f5e427fd6eb6dc388dfcc22fe6c52a73883b0480d3857fa06fb762f5feb12b4da7929f2c75f15664b4e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/16"
     },
     {
         "type": "file",
@@ -3160,17 +2831,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.0.tgz",
-        "sha512": "7ed8534ec8bc0b16815cc681003ed24f6bb2970bec9d8c61d8f7da49cc29321a2ce8a95215a8d740f70ce2880d135ab6b372dbcfd1821aa7881c2f82e8e6672a",
-        "dest-filename": "534ec8bc0b16815cc681003ed24f6bb2970bec9d8c61d8f7da49cc29321a2ce8a95215a8d740f70ce2880d135ab6b372dbcfd1821aa7881c2f82e8e6672a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7e/d8"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
-        "sha512": "39091629b8d029b1a431fff1a88d638f2de809380c28969ce7c1b6f9b8d96f77f36ba816d98ac249d31061aa136fbd1caef13ffc69e0af87f40205479aa1ef05",
-        "dest-filename": "1629b8d029b1a431fff1a88d638f2de809380c28969ce7c1b6f9b8d96f77f36ba816d98ac249d31061aa136fbd1caef13ffc69e0af87f40205479aa1ef05",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/09"
+        "url": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+        "sha512": "db13ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1",
+        "dest-filename": "ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/13"
     },
     {
         "type": "file",
@@ -3181,13 +2845,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-        "sha512": "e9e66ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c",
-        "dest-filename": "6ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/e6"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
         "sha512": "0e52fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec",
         "dest-filename": "fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec",
@@ -3195,45 +2852,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-        "sha512": "a69c13b62259ab43bf6a2d33ef27ee76d069588a3133cc84ea71e2d57e3b785476116391a9f6eee829cf94db2378debcdde4f4a86e87fcfc9ff5f09cbe39e79d",
-        "dest-filename": "13b62259ab43bf6a2d33ef27ee76d069588a3133cc84ea71e2d57e3b785476116391a9f6eee829cf94db2378debcdde4f4a86e87fcfc9ff5f09cbe39e79d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/9c"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-        "sha512": "fef06fcf925fafd753fda15677414845ff93fd0d9606c2c437281468552ab2daacc9c99900ffede41bc52532b4be2166494c6250a4d4a655b2e6fb7eaef288c6",
-        "dest-filename": "6fcf925fafd753fda15677414845ff93fd0d9606c2c437281468552ab2daacc9c99900ffede41bc52532b4be2166494c6250a4d4a655b2e6fb7eaef288c6",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/f0"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-        "sha512": "ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
-        "dest-filename": "134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/98"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-        "sha512": "5baee22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b",
-        "dest-filename": "e22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5b/ae"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
         "sha512": "36e00449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
         "dest-filename": "0449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/e0"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-        "sha512": "a15973920dc4340842936cddbfb209c1dfd0503e33d91c51c2991c198f29b0255c09864dab8c189d55802c733e6ebb6e26378f5a2605fc2966b83afc0a1e7e92",
-        "dest-filename": "73920dc4340842936cddbfb209c1dfd0503e33d91c51c2991c198f29b0255c09864dab8c189d55802c733e6ebb6e26378f5a2605fc2966b83afc0a1e7e92",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/59"
     },
     {
         "type": "file",
@@ -3248,13 +2870,6 @@
         "sha512": "91ba5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a",
         "dest-filename": "5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/ba"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-        "sha512": "d45951fa08d72bb5fe02c007b28df9327c8de4aa86c09462ff7d5fb7ac74335f7886ded2fab580bddecf1ecb3dc5228ccc4d1ab2fd69c881da258abe05b69c01",
-        "dest-filename": "51fa08d72bb5fe02c007b28df9327c8de4aa86c09462ff7d5fb7ac74335f7886ded2fab580bddecf1ecb3dc5228ccc4d1ab2fd69c881da258abe05b69c01",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/59"
     },
     {
         "type": "file",
@@ -3342,13 +2957,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-        "sha512": "0a2c9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9",
-        "dest-filename": "9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0a/2c"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
         "sha512": "6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
         "dest-filename": "50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
@@ -3377,24 +2985,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-        "sha512": "85a444ca9abbc6433b12b7e0232034cfe063e0018a94c49d9501368ef268ea1b960f511d90a615f86fd3e27ab4604176be04d3f24a8c14aa35b879fde74af849",
-        "dest-filename": "44ca9abbc6433b12b7e0232034cfe063e0018a94c49d9501368ef268ea1b960f511d90a615f86fd3e27ab4604176be04d3f24a8c14aa35b879fde74af849",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/a4"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
         "sha512": "5dae0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c",
         "dest-filename": "0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/ae"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-        "sha512": "4ddac5edf5bd469863ab8463ad6d0aa76016d00870bbdb11193912e9bbc38b4482c1994465899c7c36c4b13cfc455934107212fd57756efdc9846fb5c59b80c9",
-        "dest-filename": "c5edf5bd469863ab8463ad6d0aa76016d00870bbdb11193912e9bbc38b4482c1994465899c7c36c4b13cfc455934107212fd57756efdc9846fb5c59b80c9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/da"
     },
     {
         "type": "file",
@@ -3433,17 +3027,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-        "sha512": "b9e18b7e5aeb9efc01df1ba8fee1a86f9a5de4537b97432c2dfd19f3ba3f510991b708ef7f295f73d32eac8c51016cb00984e0aefa5705caa357839f09818221",
-        "dest-filename": "8b7e5aeb9efc01df1ba8fee1a86f9a5de4537b97432c2dfd19f3ba3f510991b708ef7f295f73d32eac8c51016cb00984e0aefa5705caa357839f09818221",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/e1"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
         "sha512": "bb2b2e9b2aef9145f4ad7fdd115aadf200b7b13073778ce859f2de4b6f676f9de299d69756f2c83585d323618dab368cbaf69c371e2e250f3e6f7cd7474a6481",
         "dest-filename": "2e9b2aef9145f4ad7fdd115aadf200b7b13073778ce859f2de4b6f676f9de299d69756f2c83585d323618dab368cbaf69c371e2e250f3e6f7cd7474a6481",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/2b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+        "sha512": "6fd11bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0",
+        "dest-filename": "1bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/d1"
     },
     {
         "type": "file",
@@ -3461,10 +3055,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-        "sha512": "de8b943a9421b60adb39ad7b27bfaec4e4e92136166863fbfc0868477f80fbfd5ef6c92bcde9468bf757cc4632bdbc6e6c417a5a7db2a6c7132a22891459f56a",
-        "dest-filename": "943a9421b60adb39ad7b27bfaec4e4e92136166863fbfc0868477f80fbfd5ef6c92bcde9468bf757cc4632bdbc6e6c417a5a7db2a6c7132a22891459f56a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/8b"
+        "url": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
+        "sha512": "29c9a8d8585f0d35dd71b7c31fbe8deee0581c837173ff065bb50056e54ff48f956b7b8749eaeb9ca57a74ba2881afe087b1a5833b820abfdea257672f59ae1b",
+        "dest-filename": "a8d8585f0d35dd71b7c31fbe8deee0581c837173ff065bb50056e54ff48f956b7b8749eaeb9ca57a74ba2881afe087b1a5833b820abfdea257672f59ae1b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/c9"
     },
     {
         "type": "file",
@@ -3489,13 +3083,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-        "sha512": "96542c30b4940d43d3e388ddad4fcedfbaa59e27e2b433fe670ae699972848ac8b2afb59c69c95d27dbf6c3fcde2d040019fe024475953b28cadaa0ad7e5d802",
-        "dest-filename": "2c30b4940d43d3e388ddad4fcedfbaa59e27e2b433fe670ae699972848ac8b2afb59c69c95d27dbf6c3fcde2d040019fe024475953b28cadaa0ad7e5d802",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/54"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
         "sha512": "b543d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73",
         "dest-filename": "d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73",
@@ -3517,13 +3104,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-        "sha512": "6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df",
-        "dest-filename": "938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/65"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
         "sha512": "36e68d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4",
         "dest-filename": "8d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4",
@@ -3538,20 +3118,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-        "sha512": "1eb82cc7ea2baa8ca09e68456ca68713a736f7a27e1d30105e8c4417a80dba944e9a6189468cb37c6ddc700bdea8206bc2bff6cb143905577f1939796a03b04a",
-        "dest-filename": "2cc7ea2baa8ca09e68456ca68713a736f7a27e1d30105e8c4417a80dba944e9a6189468cb37c6ddc700bdea8206bc2bff6cb143905577f1939796a03b04a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/b8"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-        "sha512": "4669212fc080c8244f5c2136f0c307d33d8f356401364d90d3d65dc4cf4838e5f0c7065b37ea9b59a6ad3e476458828bd99543226acdfe92b91d3473d8f712e2",
-        "dest-filename": "212fc080c8244f5c2136f0c307d33d8f356401364d90d3d65dc4cf4838e5f0c7065b37ea9b59a6ad3e476458828bd99543226acdfe92b91d3473d8f712e2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/69"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
         "sha512": "04d83d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
         "dest-filename": "3d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
@@ -3559,24 +3125,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-        "sha512": "f29d00524e173838087b04a2d25f04a63b3e1159d688aecda03204194d07844efe67263c0f520c63ba1dbb9951ac55c683bd4bd79286f10acf9ae9b8e514ed74",
-        "dest-filename": "00524e173838087b04a2d25f04a63b3e1159d688aecda03204194d07844efe67263c0f520c63ba1dbb9951ac55c683bd4bd79286f10acf9ae9b8e514ed74",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/9d"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
         "sha512": "f6efec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0",
         "dest-filename": "ec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/ef"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-        "sha512": "bf4e48da4ef137ccd7bcf0fd37ecffba15cf6a3d2c50509edab716648a41b2ac5f3fbc57150d2d8a901dff08e3d58c56c96b544b9203269386f3624ab7610054",
-        "dest-filename": "48da4ef137ccd7bcf0fd37ecffba15cf6a3d2c50509edab716648a41b2ac5f3fbc57150d2d8a901dff08e3d58c56c96b544b9203269386f3624ab7610054",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/4e"
     },
     {
         "type": "file",
@@ -3664,6 +3216,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+        "sha512": "9b0a9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88",
+        "dest-filename": "9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/0a"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
         "sha512": "25990931990018514f3f662a5d95cf6cc94c060b31cc4f082ece253085ffda8d0bf54070f4efd8de8eb0170fe2f582daa5c5095b0a9b8b791dc483dd0bad9320",
         "dest-filename": "0931990018514f3f662a5d95cf6cc94c060b31cc4f082ece253085ffda8d0bf54070f4efd8de8eb0170fe2f582daa5c5095b0a9b8b791dc483dd0bad9320",
@@ -3678,24 +3237,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-        "sha512": "9cb4eb50a9b653288beeb9616a9bbf665e3917036091919a0a965b2076a30d883094908eccb4a4f9c20f027b04a95f79e468c82c99ca6dd402d6754fcfe80061",
-        "dest-filename": "eb50a9b653288beeb9616a9bbf665e3917036091919a0a965b2076a30d883094908eccb4a4f9c20f027b04a95f79e468c82c99ca6dd402d6754fcfe80061",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/b4"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
         "sha512": "e65e15c9947ce8b67f943c594d1ea3a8bf00144d92d0814b30fdba01b8ec2d5003c4776107f734194b07fb2dfd51f0a2dddcf3f0e950b8f9a768938ca031d004",
         "dest-filename": "15c9947ce8b67f943c594d1ea3a8bf00144d92d0814b30fdba01b8ec2d5003c4776107f734194b07fb2dfd51f0a2dddcf3f0e950b8f9a768938ca031d004",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/5e"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-        "sha512": "19dd94641243917958ec66c9c5fb04f3f9ef2a45045351b7f1cd6c88de903fa6bd3d3f4c98707c1a7a6c71298c252a05f0b388aedf2e77fc0fb688f2b381bafa",
-        "dest-filename": "94641243917958ec66c9c5fb04f3f9ef2a45045351b7f1cd6c88de903fa6bd3d3f4c98707c1a7a6c71298c252a05f0b388aedf2e77fc0fb688f2b381bafa",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/dd"
     },
     {
         "type": "file",
@@ -3734,6 +3279,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+        "sha512": "701ce79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2",
+        "dest-filename": "e79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/1c"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
         "sha512": "051ed5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
         "dest-filename": "d5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
@@ -3748,17 +3300,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-        "sha512": "865abcb407e7d26ffad69e0155170fcc81abe8b2a2330a3854ce9d1a2ea9b78a9c46498dcd3716aba782123121faa5e390c0ef3e53851521b0423a046ba83230",
-        "dest-filename": "bcb407e7d26ffad69e0155170fcc81abe8b2a2330a3854ce9d1a2ea9b78a9c46498dcd3716aba782123121faa5e390c0ef3e53851521b0423a046ba83230",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/5a"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-        "sha512": "b9a5b45b05caa4bf5b957136a346d18682f61065c8ad9c50d994389a071fa01c5d16642895dfaa5ac0f68cbadf674b6b8ca2fabcec348fffde0307002c58ca4b",
-        "dest-filename": "b45b05caa4bf5b957136a346d18682f61065c8ad9c50d994389a071fa01c5d16642895dfaa5ac0f68cbadf674b6b8ca2fabcec348fffde0307002c58ca4b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/a5"
+        "url": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+        "sha512": "445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98",
+        "dest-filename": "05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/5d"
     },
     {
         "type": "file",
@@ -3766,27 +3311,6 @@
         "sha512": "f08f138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf",
         "dest-filename": "138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/8f"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-        "sha512": "eb583da4287456787b22eb598ed2c61a94c0df9e7e38f9f64f20efffa8af3f687f01d0155fd6b3b28c66836fccea765e419358044c0872c9ded6625df68408b5",
-        "dest-filename": "3da4287456787b22eb598ed2c61a94c0df9e7e38f9f64f20efffa8af3f687f01d0155fd6b3b28c66836fccea765e419358044c0872c9ded6625df68408b5",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/58"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-        "sha512": "2a22814bc0275861322f3a1f15f9af2b0a5d3f3aa2cb5e8bbd07cadf2bff7d51fb063d77ff097725247527eadf81113dabbc5424ae2abe04bcada48e78b51e87",
-        "dest-filename": "814bc0275861322f3a1f15f9af2b0a5d3f3aa2cb5e8bbd07cadf2bff7d51fb063d77ff097725247527eadf81113dabbc5424ae2abe04bcada48e78b51e87",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/22"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-        "sha512": "1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
-        "dest-filename": "c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/92"
     },
     {
         "type": "file",
@@ -3801,34 +3325,6 @@
         "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
         "dest-filename": "9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/ef"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-        "sha512": "1422c7b510ff827a428821c48892cec1d9853fec330a60c491cf72ecdb18c5e178bbb06db27d59bb0830246c4898898789c240acb3f8474c97e1cd8a0ab32b4c",
-        "dest-filename": "c7b510ff827a428821c48892cec1d9853fec330a60c491cf72ecdb18c5e178bbb06db27d59bb0830246c4898898789c240acb3f8474c97e1cd8a0ab32b4c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/22"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-        "sha512": "5428c235f80cb1bcb7b53768d369db8ed33f7b0adaea33c79a94e17a7913621f291bdb9c67fd4ff12a38bb814605e93f063a4e56c0c23282c0fe2b8128815744",
-        "dest-filename": "c235f80cb1bcb7b53768d369db8ed33f7b0adaea33c79a94e17a7913621f291bdb9c67fd4ff12a38bb814605e93f063a4e56c0c23282c0fe2b8128815744",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/28"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-        "sha512": "58f4bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8",
-        "dest-filename": "bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/58/f4"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-        "sha512": "657f7d7bab51c1ea145ea47e541aec96175ae75361e4c4d0c28bb9b6750381bb723347418268440ed5863ffc5b2a7ea1a9f3d11ee8d4370cf97f2ff06db867a7",
-        "dest-filename": "7d7bab51c1ea145ea47e541aec96175ae75361e4c4d0c28bb9b6750381bb723347418268440ed5863ffc5b2a7ea1a9f3d11ee8d4370cf97f2ff06db867a7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/7f"
     },
     {
         "type": "file",
@@ -3888,10 +3384,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-        "sha512": "979c7b5545166e35456da7c62f13d6918b0722112f985f39b5b21e15959cf193eda0ccb26ee1212fb2727bfa280b8fdde3c1603a34895e0b05fc024f6025bc67",
-        "dest-filename": "7b5545166e35456da7c62f13d6918b0722112f985f39b5b21e15959cf193eda0ccb26ee1212fb2727bfa280b8fdde3c1603a34895e0b05fc024f6025bc67",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/9c"
+        "url": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+        "sha512": "0f761a0f4691c51de611caa789d22ced179824557359d77a7d725850cf22c5c41c25119391afdbdec695d0a7e5621c952572a16fde3b1a7754df94b160d45eb1",
+        "dest-filename": "1a0f4691c51de611caa789d22ced179824557359d77a7d725850cf22c5c41c25119391afdbdec695d0a7e5621c952572a16fde3b1a7754df94b160d45eb1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/76"
     },
     {
         "type": "file",
@@ -3937,13 +3433,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-        "sha512": "470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475",
-        "dest-filename": "40f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/03"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
         "sha512": "6aa0f6434d78e19fbf46a1b9d8d78712465ab930145893bc73ac937ed18928edd38dae6d52021f98897a904c6f86dc520cfedf5c1e83bf391f32909dfc5dc6f9",
         "dest-filename": "f6434d78e19fbf46a1b9d8d78712465ab930145893bc73ac937ed18928edd38dae6d52021f98897a904c6f86dc520cfedf5c1e83bf391f32909dfc5dc6f9",
@@ -3972,13 +3461,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-        "sha512": "9ff4a19ef0e2e851db6d57ef8aba3e5a88e2173bfeb3c30f30705ccd578f7d4a4324bc282d3d21b759786300426e2f29240bde104767907c8fc933ff9b345fc2",
-        "dest-filename": "a19ef0e2e851db6d57ef8aba3e5a88e2173bfeb3c30f30705ccd578f7d4a4324bc282d3d21b759786300426e2f29240bde104767907c8fc933ff9b345fc2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/f4"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
         "sha512": "864457f14d568c915df0bb03276c90ff0596c5aa2912c0015355df90cf00fa3d3ef392401a9a6dd7a72bd56860e8a21b6f8a2453a32a97a04e8febaea7fc0a78",
         "dest-filename": "57f14d568c915df0bb03276c90ff0596c5aa2912c0015355df90cf00fa3d3ef392401a9a6dd7a72bd56860e8a21b6f8a2453a32a97a04e8febaea7fc0a78",
@@ -3997,13 +3479,6 @@
         "sha512": "8aae9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471",
         "dest-filename": "9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8a/ae"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-        "sha512": "74e112aa362bf7a89663294639bcdddfd12e3536b9549c72bd50049b926787b286a3be55e371e4d6874f424343c97366511ea4fa01220d55e78c1f0727772b5f",
-        "dest-filename": "12aa362bf7a89663294639bcdddfd12e3536b9549c72bd50049b926787b286a3be55e371e4d6874f424343c97366511ea4fa01220d55e78c1f0727772b5f",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/e1"
     },
     {
         "type": "file",
@@ -4028,13 +3503,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-        "sha512": "ba37aa6dc780060c0c6711099e4d870d8d83967519fbda0471bd4acd355f6078a8d1413a746ef59fad1df03d88e2a36f95e5abad7a668e9b7bbd9785d4b9cc65",
-        "dest-filename": "aa6dc780060c0c6711099e4d870d8d83967519fbda0471bd4acd355f6078a8d1413a746ef59fad1df03d88e2a36f95e5abad7a668e9b7bbd9785d4b9cc65",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ba/37"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
         "sha512": "0d9e323914f0adb4e3ffb31962adb0fbf645748e8e67f7fd4851d1fbbd6021551984e40f1f35422e9bd19cf83268ca5f5b1c64ff838dbdadc6412c8d20a46fe8",
         "dest-filename": "323914f0adb4e3ffb31962adb0fbf645748e8e67f7fd4851d1fbbd6021551984e40f1f35422e9bd19cf83268ca5f5b1c64ff838dbdadc6412c8d20a46fe8",
@@ -4046,6 +3514,13 @@
         "sha512": "0b9b63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6",
         "dest-filename": "63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/9b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+        "sha512": "c98aebb169eb5cc71db27bbfed83180287ccd64b692f9072eef6617f5e42ad78a3596ac461992ce405c1b9d6a57d25892e59de9ff4142540796a807492a65418",
+        "dest-filename": "ebb169eb5cc71db27bbfed83180287ccd64b692f9072eef6617f5e42ad78a3596ac461992ce405c1b9d6a57d25892e59de9ff4142540796a807492a65418",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/8a"
     },
     {
         "type": "file",
@@ -4063,6 +3538,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+        "sha512": "d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
+        "dest-filename": "00c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/51"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
         "sha512": "a95b6f3317976d57a3d1c4162aa5524801e629910702fc5d17c1c4501156b6cf21fb1128e66fe51223da92ec99dc19c2063383f22db893334e88e2cb82c4b184",
         "dest-filename": "6f3317976d57a3d1c4162aa5524801e629910702fc5d17c1c4501156b6cf21fb1128e66fe51223da92ec99dc19c2063383f22db893334e88e2cb82c4b184",
@@ -4070,10 +3552,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-        "sha512": "290411f7237b479f8e4b068ad174288f6da9c07a1396062a994b1c3d8a249cea160967e3ff9fc00533118baf45aca5397df3d587941c16292958923f3f5a1c1c",
-        "dest-filename": "11f7237b479f8e4b068ad174288f6da9c07a1396062a994b1c3d8a249cea160967e3ff9fc00533118baf45aca5397df3d587941c16292958923f3f5a1c1c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/04"
+        "url": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+        "sha512": "e6e0ba0c39667aa88ec023e62bd8cc49d3ae65387c6d4dfd62ceb289d07e513b7985f6543c6032a52805462129fa36e2f6a1f8d012c3bf2f398c853cf30292ab",
+        "dest-filename": "ba0c39667aa88ec023e62bd8cc49d3ae65387c6d4dfd62ceb289d07e513b7985f6543c6032a52805462129fa36e2f6a1f8d012c3bf2f398c853cf30292ab",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/e0"
     },
     {
         "type": "file",
@@ -4095,13 +3577,6 @@
         "sha512": "eb93fb8b3e97e7212bd5cc1c82f4316db230ed493780ecb974876d678ac3bde2ea86b7493fe2e2fc7c7ab722b43446fed860b29de08c2621aaac00c248d93cb1",
         "dest-filename": "fb8b3e97e7212bd5cc1c82f4316db230ed493780ecb974876d678ac3bde2ea86b7493fe2e2fc7c7ab722b43446fed860b29de08c2621aaac00c248d93cb1",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/93"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-        "sha512": "a39b123ca12483f0c840d987e37574fee7ab2eba7355e764521f2d18dbda797a5fa6ec2329e9e54a8c7fd8efc14e5654b447be246eece58844cfad3c3e500744",
-        "dest-filename": "123ca12483f0c840d987e37574fee7ab2eba7355e764521f2d18dbda797a5fa6ec2329e9e54a8c7fd8efc14e5654b447be246eece58844cfad3c3e500744",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/9b"
     },
     {
         "type": "file",
@@ -4133,17 +3608,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-        "sha512": "399b3a82c8c5e2f329df6aab09b8954a4ac5997b46fc0661637b7488032b30188067257da002ed5cef21b2b1db31717dc7a2f782b945bb05b6a00cfb71abfe1b",
-        "dest-filename": "3a82c8c5e2f329df6aab09b8954a4ac5997b46fc0661637b7488032b30188067257da002ed5cef21b2b1db31717dc7a2f782b945bb05b6a00cfb71abfe1b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/9b"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.0.tgz",
-        "sha512": "50cab69317570b38a71453ec5dcf68da8cc8a580823a2102e3a306df2121e558a9aba04edbba2d4ed101640d5f43ae83ba5114804f7bb9c43fdd863ae823e0d0",
-        "dest-filename": "b69317570b38a71453ec5dcf68da8cc8a580823a2102e3a306df2121e558a9aba04edbba2d4ed101640d5f43ae83ba5114804f7bb9c43fdd863ae823e0d0",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/ca"
+        "url": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
+        "sha512": "0fb7a5f9e6831c0997beb641cb5ce9cd234846a9c23ab9304e06714eedcc52a45693c934abd9bd1e8e3ebcf7fb887b6051facafe8f0865a100a6cc4f9474c50a",
+        "dest-filename": "a5f9e6831c0997beb641cb5ce9cd234846a9c23ab9304e06714eedcc52a45693c934abd9bd1e8e3ebcf7fb887b6051facafe8f0865a100a6cc4f9474c50a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/b7"
     },
     {
         "type": "file",
@@ -4196,13 +3664,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-        "sha512": "a63cb66d8852b2e7f05a52b03dcfa5ddc37bfb0b8994aeaecf461d2443a54036e5ea3a3f6253e2e266fc6a0524542f0117b57c36ecdec8f36a464b00de1ced29",
-        "dest-filename": "b66d8852b2e7f05a52b03dcfa5ddc37bfb0b8994aeaecf461d2443a54036e5ea3a3f6253e2e266fc6a0524542f0117b57c36ecdec8f36a464b00de1ced29",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/3c"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
         "sha512": "eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
         "dest-filename": "94cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
@@ -4224,13 +3685,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-        "sha512": "04d19b58b7ddd1e50f69b8645d4566d23f2ebaf444c93879a2f45afddca8c3f06a01b649c82fb97d4f88cd03b39802b362a6110084a8461750af778867f3d7aa",
-        "dest-filename": "9b58b7ddd1e50f69b8645d4566d23f2ebaf444c93879a2f45afddca8c3f06a01b649c82fb97d4f88cd03b39802b362a6110084a8461750af778867f3d7aa",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/d1"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
         "sha512": "bdeb9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e",
         "dest-filename": "9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e",
@@ -4249,13 +3703,6 @@
         "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
         "dest-filename": "374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/b2"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-        "sha512": "78330e45868f359e2c408bae60f0c7750bdfe20c8217dac4115ff23f119fc0f911a1dc048223145174f1fdd7b1f8c7b4c31c79dd2f8d8141da3fbcb73069439a",
-        "dest-filename": "0e45868f359e2c408bae60f0c7750bdfe20c8217dac4115ff23f119fc0f911a1dc048223145174f1fdd7b1f8c7b4c31c79dd2f8d8141da3fbcb73069439a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/78/33"
     },
     {
         "type": "file",
@@ -4315,10 +3762,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-        "sha512": "fa14a8cbf40796ec660bd902209c8bfeec8598b99cf9ee42151e566be6e9221223f392d56fd647da7567aab1e84af2a8830383bf40a5a9992689249a207e4b4c",
-        "dest-filename": "a8cbf40796ec660bd902209c8bfeec8598b99cf9ee42151e566be6e9221223f392d56fd647da7567aab1e84af2a8830383bf40a5a9992689249a207e4b4c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/14"
+        "url": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+        "sha512": "e252dafc4710081d1c264cadb3e169211c791bf9653f17cfe95414e4a0721c484bc58dc82421f47f41f2d4c1c8f2c0a54efb086fcab0449e91fd97650c9fe579",
+        "dest-filename": "dafc4710081d1c264cadb3e169211c791bf9653f17cfe95414e4a0721c484bc58dc82421f47f41f2d4c1c8f2c0a54efb086fcab0449e91fd97650c9fe579",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/52"
     },
     {
         "type": "file",
@@ -4350,24 +3797,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.0.tgz",
-        "sha512": "287042ef3eb538979a3069c5df0a8d663f8618d5cecb2a59be288aa507a21e2ac6e486f5226c1c2c11fbd2b6cc4a429f4a650d06c75fd8fc1a109b4abe09a437",
-        "dest-filename": "42ef3eb538979a3069c5df0a8d663f8618d5cecb2a59be288aa507a21e2ac6e486f5226c1c2c11fbd2b6cc4a429f4a650d06c75fd8fc1a109b4abe09a437",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/70"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
-        "sha512": "f6abf8ae50e2a295e0e04ebd93ebcc1e334deb760531ef6c64cadd96f2a70a394245678206cc0f3cc3d47f1fa2a6c016ab52d71deef445c6da1dd249a52ea1c9",
-        "dest-filename": "f8ae50e2a295e0e04ebd93ebcc1e334deb760531ef6c64cadd96f2a70a394245678206cc0f3cc3d47f1fa2a6c016ab52d71deef445c6da1dd249a52ea1c9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/ab"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-        "sha512": "fc0b96c0c3fe62a88f6ec271e43e937e04537389132e3b21e5239c7786cbb1f520d917045eb14c265d431a0747cb66827ec200fdcaffd49334c5c0761998e2f2",
-        "dest-filename": "96c0c3fe62a88f6ec271e43e937e04537389132e3b21e5239c7786cbb1f520d917045eb14c265d431a0747cb66827ec200fdcaffd49334c5c0761998e2f2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/0b"
+        "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+        "sha512": "0327846d63aefd3017771955f70986711d3eca1da3def60f18e1027088f64bb324acbc82ee77bea327b604a4c8b6dd228b63c7938703cbef79f8bb21cdb5e71a",
+        "dest-filename": "846d63aefd3017771955f70986711d3eca1da3def60f18e1027088f64bb324acbc82ee77bea327b604a4c8b6dd228b63c7938703cbef79f8bb21cdb5e71a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/03/27"
     },
     {
         "type": "file",
@@ -4377,16 +3810,16 @@
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/da"
     },
     {
+        "type": "git",
+        "url": "https://git@github.com/electron/node-gyp.git",
+        "commit": "06b29aafb7708acef8b3669835c8a7857ebc92d2",
+        "dest": "flatpak-node/git-packages/@electron/node-gyp-06b29aafb7708acef8b3669835c8a7857ebc92d2"
+    },
+    {
         "type": "inline",
         "contents": "010de3298ba09e916861045c7a74d2f8afa9f7e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz\", \"integrity\": \"sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==\", \"time\": 0, \"size\": 181128, \"metadata\": {\"url\": \"https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "a73778bc7fe534d3788b3e6309e2b9294c66be6787edc101287012ba2c7c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/46"
-    },
-    {
-        "type": "inline",
-        "contents": "011a05540844b8ae7bd66dd674f148fa56c5d50e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz\", \"integrity\": \"sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==\", \"time\": 0, \"size\": 4496, \"metadata\": {\"url\": \"https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1f558f51da8495fa9d3fee9e4aa8c6cfc9809b10931f4df310e7bb0fe42b",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/ef"
     },
     {
         "type": "inline",
@@ -4402,21 +3835,15 @@
     },
     {
         "type": "inline",
-        "contents": "01a51194fb337ec32aae27a73d8374b277c6a788\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz\", \"integrity\": \"sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==\", \"time\": 0, \"size\": 620817, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e222868d97426a3bf4915767f3d195e813f491c4d56a1dd15419e8344c84",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/58"
+        "contents": "01c00565b799b2a2ad8d1d419358e4ef36d8c3fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-9.5.0.tgz\", \"integrity\": \"sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==\", \"time\": 0, \"size\": 44526, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-9.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ba2e0f724389afe9916b645aa486202f4dd28493d3be6ed3399afa0fcaea",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/2a"
     },
     {
         "type": "inline",
-        "contents": "03064258be095fc23f344b6bd16a9299c85e1afa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.0.tgz\", \"integrity\": \"sha512-pU9VD7anSCOIoBFnhTGfOzlVFQIA1XXiQpH/CezqOBaDppRwTglJzCC6fUQGpfwey4T183NKhF1/mfatYmjRqQ==\", \"time\": 0, \"size\": 81181, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "47cae915e7257f55bb1e9d28e1f8bf975d9464eeb24347981372340d4e3b",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/41"
-    },
-    {
-        "type": "inline",
-        "contents": "03338782531576f8c87715e52416877d8e5e88af\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz\", \"integrity\": \"sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==\", \"time\": 0, \"size\": 28026, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "dd5e6f02ebea3574006624e5dd81e72b124d66a1bd1598ab078fda7118f7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/cb"
+        "contents": "02bd9dbe1f1aae1bbde4d5fd3600b84bdbc58c78\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz\", \"integrity\": \"sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==\", \"time\": 0, \"size\": 9751, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "08b102eeb38fa187c941181cf747d5a18478c9f716ae1caed282e19b8215",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/a5"
     },
     {
         "type": "inline",
@@ -4456,12 +3883,6 @@
     },
     {
         "type": "inline",
-        "contents": "059f780df31408ab437755fc9c28f95aad562fe0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz\", \"integrity\": \"sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==\", \"time\": 0, \"size\": 15400, \"metadata\": {\"url\": \"https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "38a71d0d155f93c889c23eeac2e974c7880195ee3a2c9d3c5a2639dd84d5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/28"
-    },
-    {
-        "type": "inline",
         "contents": "06022677fd1ed26bdbdea1d78e2a8753261e92fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz\", \"integrity\": \"sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==\", \"time\": 0, \"size\": 20536, \"metadata\": {\"url\": \"https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9e94fd5b365d5d037e35596fb3e68922fcffbb82e5310ebe34f0a009febf",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/3d"
@@ -4486,21 +3907,9 @@
     },
     {
         "type": "inline",
-        "contents": "06cdb2fc91f00f2663b9b3f5bc898a5e3a7d6b03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz\", \"integrity\": \"sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==\", \"time\": 0, \"size\": 24143, \"metadata\": {\"url\": \"https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "78c5fefa79fb86a1494da5cf2f3366181e7aa06aa141ef99f32ccb487467",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/58"
-    },
-    {
-        "type": "inline",
         "contents": "0714a2a394f268aa28aece96be6799022392d402\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz\", \"integrity\": \"sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==\", \"time\": 0, \"size\": 4345, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "47e273da29b52c911f59eca44c62faa84be4bb59b1de259ba100ff968559",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/5a/8c"
-    },
-    {
-        "type": "inline",
-        "contents": "0724c6155c5f13604a029b609b49c2533c922433\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz\", \"integrity\": \"sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==\", \"time\": 0, \"size\": 1620, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a476f136002620b39026df5b6306a63af83b27d9a8de03c88305fd2b328e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/9d"
     },
     {
         "type": "inline",
@@ -4522,9 +3931,27 @@
     },
     {
         "type": "inline",
+        "contents": "0858b37ac0d2453e553d2e0a74b9df01ee2cadb3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz\", \"integrity\": \"sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==\", \"time\": 0, \"size\": 22342, \"metadata\": {\"url\": \"https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "25a1b4247395c35245e9b9739efa05217fb5d5e2736bbf292b161ca1ff9e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/dc"
+    },
+    {
+        "type": "inline",
         "contents": "08f70474f0a819721a36f4141d951f4775819862\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz\", \"integrity\": \"sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==\", \"time\": 0, \"size\": 15520, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "575503a996b3678372373e36b1adcb0ecf0c5e27804be136f2f9b46a57fa",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/71/9b"
+    },
+    {
+        "type": "inline",
+        "contents": "09c678964a5885453de438c2b508d0a9bbae1e1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz\", \"integrity\": \"sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==\", \"time\": 0, \"size\": 2732, \"metadata\": {\"url\": \"https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5221448e8c3990b22267bb8a1f5cd80dc3cf431aeed10551e17b86620a2d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/cd"
+    },
+    {
+        "type": "inline",
+        "contents": "09c7ff142621ecb9204e3cebbf3aff1b2f82a2b2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz\", \"integrity\": \"sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==\", \"time\": 0, \"size\": 3060, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b75e1b4057be918d8e4c016d0e0ae4165d8bf1106723baad1f2a518a433b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/42"
     },
     {
         "type": "inline",
@@ -4534,9 +3961,9 @@
     },
     {
         "type": "inline",
-        "contents": "0a078b0c48359b4c20385f2a37290e977d0df120\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz\", \"integrity\": \"sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==\", \"time\": 0, \"size\": 2675, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "21f3b978a3a22da2c741a07872da75d54875dd2620f1fbe58f0b0f9d92a9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/b8"
+        "contents": "0a3076e41cd1549b391a6dbecc819be89ba5bec0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz\", \"integrity\": \"sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==\", \"time\": 0, \"size\": 4149, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d7972a21e7b5f5d19bafa978462b75f7461e559ceab84df183e51a3a72b0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2e/f2"
     },
     {
         "type": "inline",
@@ -4546,9 +3973,21 @@
     },
     {
         "type": "inline",
+        "contents": "0a551879e0bd8a6ac5bb276b305b9fd175644a3a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz\", \"integrity\": \"sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==\", \"time\": 0, \"size\": 74229, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3c67cd8d314077a50c8b25f9f558594bc2bfd7393a4e6a9a58250956aa7a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/47"
+    },
+    {
+        "type": "inline",
         "contents": "0a77d02ee877012bef5d491661500e4c26fb2f41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz\", \"integrity\": \"sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==\", \"time\": 0, \"size\": 5556, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6052f9b7b7c39d12067339763f1c9b7e1a2d9ca4312a5161bc6356a7f60d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/72/ba"
+    },
+    {
+        "type": "inline",
+        "contents": "0a7e1c010bef8c401e295c5f33a42b8e63c0500b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz\", \"integrity\": \"sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==\", \"time\": 0, \"size\": 7103, \"metadata\": {\"url\": \"https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c88ed06e1ffc6d86354afa40962377f10eb8fc4870314ddd9e77c4e1c828",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/37"
     },
     {
         "type": "inline",
@@ -4576,21 +4015,9 @@
     },
     {
         "type": "inline",
-        "contents": "0c5c3996e3c462a022e2ba21c9acc83b1a0bf2cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz\", \"integrity\": \"sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==\", \"time\": 0, \"size\": 58169, \"metadata\": {\"url\": \"https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "11d6cbb4f337149253b2f26c9d15cac479396622ad9be8abc51439c56ef9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/41"
-    },
-    {
-        "type": "inline",
         "contents": "0e40cbf9308f2e5d26a71e11a284fc81e9f61231\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz\", \"integrity\": \"sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==\", \"time\": 0, \"size\": 2915, \"metadata\": {\"url\": \"https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "a5cf38e6aac27d8eb3fdaf635d75bf88ff4a3f834e89358608c7b67cb33d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/5e"
-    },
-    {
-        "type": "inline",
-        "contents": "0e536d6dfcad75478c00c0e3b148b07d363ca7eb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz\", \"integrity\": \"sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==\", \"time\": 0, \"size\": 34296, \"metadata\": {\"url\": \"https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3479f723a5a8d97f8e8c0951ccd883bebaa82eba8bb33842e1e06e2788d8",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/c4"
     },
     {
         "type": "inline",
@@ -4630,6 +4057,12 @@
     },
     {
         "type": "inline",
+        "contents": "0fb790dbb869078cf2a549139425e3fdddbe4032\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz\", \"integrity\": \"sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==\", \"time\": 0, \"size\": 7840, \"metadata\": {\"url\": \"https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f704fa32df56d3700f0713f5eaf53cfeea98ec44318b7b20aab5f70bd3da",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/48"
+    },
+    {
+        "type": "inline",
         "contents": "0fbc95ea5dea0d69d1f87ff0e1945487a26153d0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz\", \"integrity\": \"sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==\", \"time\": 0, \"size\": 15335, \"metadata\": {\"url\": \"https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3f6da259c54cf26b9cc43d7f33fb4b472cc1b9e9b0e5a0ae1463dfa3e2bd",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/11"
@@ -4642,15 +4075,9 @@
     },
     {
         "type": "inline",
-        "contents": "1129b9daa8bc7cc81f936208bc6555ed6c814009\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz\", \"integrity\": \"sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==\", \"time\": 0, \"size\": 5460, \"metadata\": {\"url\": \"https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ade93a0f735f87797a660fb51fe96280b1739a94d2ea6b4fc108840809c8",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/17"
-    },
-    {
-        "type": "inline",
-        "contents": "118708ce2bfc4b7acb1ee44bd7d6961d694719c4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz\", \"integrity\": \"sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==\", \"time\": 0, \"size\": 6903, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "50cf5529157a80f13b6d83e912d403100e06e598fa796a8daa87cd161a2c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/1a"
+        "contents": "108210605b65de303ac70816dcb5a026e9e9e789\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.1.tgz\", \"integrity\": \"sha512-BfcvzBlUTxSDWfT+oH7vd6CbUV+rThLLHCIym/QO6GGLBsyVXleZs00fto2i2jzC/wPiBYk5jyOmpXWg4YopiA==\", \"time\": 0, \"size\": 11852, \"metadata\": {\"url\": \"https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "999bbf0c0f58614220f43f038fe14e6536b01bbcff91ac90e8d118503979",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/8c"
     },
     {
         "type": "inline",
@@ -4660,9 +4087,21 @@
     },
     {
         "type": "inline",
+        "contents": "1297919ce9e597706d5ee3c5853ec318e791646d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lint-staged/-/lint-staged-16.0.0.tgz\", \"integrity\": \"sha512-sUCprePs6/rbx4vKC60Hez6X10HPkpDJaGcy3D1NdwR7g1RcNkWL8q9mJMreOqmHBTs+1sNFp+wOiX9fr+hoOQ==\", \"time\": 0, \"size\": 40084, \"metadata\": {\"url\": \"https://registry.npmjs.org/lint-staged/-/lint-staged-16.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b98da3e942d3a6044381f8ffe18f1b10c89d4cc8be5282bf9270c565d951",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/1f"
+    },
+    {
+        "type": "inline",
         "contents": "12aefe1710b91a4cf486fdd85894cc55ad2cd37f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz\", \"integrity\": \"sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==\", \"time\": 0, \"size\": 4854, \"metadata\": {\"url\": \"https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "7242a3a8f46187d645dab73891fb0b362a1297afef4d28c91f881bb56fe6",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/f3"
+    },
+    {
+        "type": "inline",
+        "contents": "136ca2a9d730e186af2a0a96e1d38ea6b3851dce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz\", \"integrity\": \"sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==\", \"time\": 0, \"size\": 5451, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a0816a7152eeb870edea4f2c8aadd6805d2a0f543311c6d32e8569adbe25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/66"
     },
     {
         "type": "inline",
@@ -4684,18 +4123,6 @@
     },
     {
         "type": "inline",
-        "contents": "16942c3b2a40eb4a5619c34f4caac8f411e39ee9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz\", \"integrity\": \"sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==\", \"time\": 0, \"size\": 25795, \"metadata\": {\"url\": \"https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c33eceee9d3b74e42f13b81badd96d6cb43cdae9afab2dfe979a64d44521",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1f/24"
-    },
-    {
-        "type": "inline",
-        "contents": "16ab23bd14136752bd2928a110b2b985153e16af\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz\", \"integrity\": \"sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==\", \"time\": 0, \"size\": 2220, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d0da41bce03a4f93c356aad01d2d236c672e6c828796867d148607bbaeb3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/01"
-    },
-    {
-        "type": "inline",
         "contents": "16c447d9067175bead72b1203150f5a467a91c78\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz\", \"integrity\": \"sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==\", \"time\": 0, \"size\": 2234, \"metadata\": {\"url\": \"https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d8752773e2be8ff244bc63d0f84ad951e7bb0cfe9ef06e130b57fdeb53ba",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/d9"
@@ -4714,9 +4141,9 @@
     },
     {
         "type": "inline",
-        "contents": "1ad5a7e4118dd5cef58b4acaaca43e245be61fbd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.0.tgz\", \"integrity\": \"sha512-8S9hXau6nQ/sYVtC3D6ISIDoJzS1NsCK+gluVhLN2YkBPX+/1wkwyUiDKnxRh15579WoOIyVWnoyIf3yGI9REw==\", \"time\": 0, \"size\": 55886, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b5bf6efe7693e124f516f270085fd33c7824f4dfc9fa068c77e5f568df82",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/d4"
+        "contents": "1aba3eae70d19eb037b94430968113736cc0f03b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-builder/-/electron-builder-26.0.12.tgz\", \"integrity\": \"sha512-cD1kz5g2sgPTMFHjLxfMjUK5JABq3//J4jPswi93tOPFz6btzXYtK5NrDt717NRbukCUDOrrvmYVOWERlqoiXA==\", \"time\": 0, \"size\": 19934, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-builder/-/electron-builder-26.0.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b85b27b5fa816af90281a64552deef57a466f9fe1ccb10f8c0921b31b3b2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0e/25"
     },
     {
         "type": "inline",
@@ -4738,6 +4165,12 @@
     },
     {
         "type": "inline",
+        "contents": "1c1ac43b2fa7307f299fe939aab7f85c0f732f98\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz\", \"integrity\": \"sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==\", \"time\": 0, \"size\": 1971, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c444bafe5c0476d463a2828b06c3e0ac27174d59dd79e19e4953812aa67f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/c9"
+    },
+    {
+        "type": "inline",
         "contents": "1c275b895232327f3f26f15c37cebdf5c39e98ed\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz\", \"integrity\": \"sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==\", \"time\": 0, \"size\": 7276, \"metadata\": {\"url\": \"https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3b08da5f899fa3fed549feab0409bd61817b55fd96ba7dc01ffbcbb45258",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/23"
@@ -4750,27 +4183,9 @@
     },
     {
         "type": "inline",
-        "contents": "1cd3cc3588abe2d185d34a71f5d982e3aa80ffb2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz\", \"integrity\": \"sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==\", \"time\": 0, \"size\": 11501, \"metadata\": {\"url\": \"https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "fa22a40eb0cb07176c21351dda1ab02f692d46b49a71c6469daf50c8f69c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/ab"
-    },
-    {
-        "type": "inline",
-        "contents": "1d5eec4b25d4b86da544b47816610d418d4b66db\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz\", \"integrity\": \"sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==\", \"time\": 0, \"size\": 5029, \"metadata\": {\"url\": \"https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c11d73610ad757b63c843c9fb700bf748bfd1f5a6bfe1abc6e735c1039a6",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/6c"
-    },
-    {
-        "type": "inline",
-        "contents": "1ecf3c45a727bff759c7cec96f5796d5a8f04806\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz\", \"integrity\": \"sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==\", \"time\": 0, \"size\": 1917, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f7ae5128341e8be6a414b2ff18919cb6c0b5e5392b7fe3b66b26448cf68a",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/da"
-    },
-    {
-        "type": "inline",
-        "contents": "1ee6675af3de6c762126cce869559d2449e7ad4b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz\", \"integrity\": \"sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==\", \"time\": 0, \"size\": 8452, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "9b9cb0ad98fbd74697e17a32e16f01409a068a0d10e98b17b8e5a4fecb2c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/bf"
+        "contents": "1d58e25734b3951feafbf567d5e945d11d0096ba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz\", \"integrity\": \"sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==\", \"time\": 0, \"size\": 16825, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "47ba321b37f695a79668b4434d63f6dcb7f98dc2447a78e96305be133d4d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/6c"
     },
     {
         "type": "inline",
@@ -4786,15 +4201,9 @@
     },
     {
         "type": "inline",
-        "contents": "1f89e266cdb060a757258c87ba956af74997bb73\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz\", \"integrity\": \"sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==\", \"time\": 0, \"size\": 2260, \"metadata\": {\"url\": \"https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "750b657573673939685035422dc61c96c9b85b96eb729d14f6441e9065e7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7a/1e"
-    },
-    {
-        "type": "inline",
-        "contents": "1fc2ac28191e1a3facb05fa59ccc47db8233fa10\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz\", \"integrity\": \"sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==\", \"time\": 0, \"size\": 12591, \"metadata\": {\"url\": \"https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f6a01e6512d62291bea9870b113f974adf9337b46ee548b56d3a7006526d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/dd"
+        "contents": "203249fbad3ef9ec844b1432b3da05e93d8d692c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz\", \"integrity\": \"sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==\", \"time\": 0, \"size\": 9969, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "67c0439786ca317dcf1f35da2f1deb40a8d3af361597b4de45afbc9d4704",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/63"
     },
     {
         "type": "inline",
@@ -4810,9 +4219,21 @@
     },
     {
         "type": "inline",
-        "contents": "22acbcb507b399d60f45dfad94d7e4947fc541c0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz\", \"integrity\": \"sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==\", \"time\": 0, \"size\": 3952, \"metadata\": {\"url\": \"https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "19bb6590f7312f358d7385c3500c0043cd60e890b804af0c9b986c3c5a94",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/eb/22"
+        "contents": "22a56a4cd0414d0b3690becdec4e1ebf13f0e0dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz\", \"integrity\": \"sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==\", \"time\": 0, \"size\": 1951, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6149661c453e9896445eb249a914c680462121e4f460635ec401d9394202",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/73"
+    },
+    {
+        "type": "inline",
+        "contents": "22e99f159af9c1460328d75a650d94643afbbea4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz\", \"integrity\": \"sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==\", \"time\": 0, \"size\": 55886, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c02af7cd04efc42e96abc884e94810748cc435f5e49916621351934be6e4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/24"
+    },
+    {
+        "type": "inline",
+        "contents": "2318764fbca593874abfac05becf08568d989739\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz\", \"integrity\": \"sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==\", \"time\": 0, \"size\": 27935, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "243681d3b671bccec51057521ae9b510a71a5276d31fd689eb8592a142d1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/c8"
     },
     {
         "type": "inline",
@@ -4828,6 +4249,12 @@
     },
     {
         "type": "inline",
+        "contents": "242de372dfbc8fedd0b37457973e0022f179eb84\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz\", \"integrity\": \"sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==\", \"time\": 0, \"size\": 4199, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3c2bb41bc34383473d3ee591593feaadc120b067e30d74144288b8bb69e4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/ba"
+    },
+    {
+        "type": "inline",
         "contents": "244036e4362860dbf936e83073280bef4a5e4045\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz\", \"integrity\": \"sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==\", \"time\": 0, \"size\": 4312, \"metadata\": {\"url\": \"https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e444d001268ef2d4c2a6c96efcf4cbe9d51fdc9008329f7956b60986aef9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/28"
@@ -4837,12 +4264,6 @@
         "contents": "251bb695bd3992779fde95c94f21053d3cfc6933\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz\", \"integrity\": \"sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==\", \"time\": 0, \"size\": 7258, \"metadata\": {\"url\": \"https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "df9ad1e665a5540bb2f402039c619e67bce9aad000c3bfd8dd9afd7c268a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/25"
-    },
-    {
-        "type": "inline",
-        "contents": "252fcae03e77c01520234bd6a24ef25a653c5be3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz\", \"integrity\": \"sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==\", \"time\": 0, \"size\": 5280, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "58c14b3461e0a75ddd4a0be80707cae7f82bf1ef1ae03a0dfc8054aa2570",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/3b"
     },
     {
         "type": "inline",
@@ -4870,24 +4291,6 @@
     },
     {
         "type": "inline",
-        "contents": "270863d181e5d7eceeff16e151191a4f4cb83673\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-updater/-/electron-updater-6.3.9.tgz\", \"integrity\": \"sha512-2PJNONi+iBidkoC5D1nzT9XqsE8Q1X28Fn6xRQhO3YX8qRRyJ3mkV4F1aQsuRnYPqq6Hw+E51y27W75WgDoofw==\", \"time\": 0, \"size\": 113523, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-updater/-/electron-updater-6.3.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "9cee0f815a5f488c51df4fe83c2d8341ef92c7743f36ec13faa9c7f1aa4f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/02"
-    },
-    {
-        "type": "inline",
-        "contents": "27f41a84f35b71366c1c3c33f95fb70ba0d5a035\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vary/-/vary-1.1.2.tgz\", \"integrity\": \"sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==\", \"time\": 0, \"size\": 3772, \"metadata\": {\"url\": \"https://registry.npmjs.org/vary/-/vary-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "bc6ddfe7826874158ab240154ebbd8569ff129493af149bcc64cca3537c1",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/1f"
-    },
-    {
-        "type": "inline",
-        "contents": "284997f6b860329df5686bae3c93641b48f30d01\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz\", \"integrity\": \"sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==\", \"time\": 0, \"size\": 2096, \"metadata\": {\"url\": \"https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4226971e16d707d9180cd9fe4d4c5d07b40fa7d4311fe932f69a7fce4e53",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/bf"
-    },
-    {
-        "type": "inline",
         "contents": "28512f2f3de55bd2dcfee4dc8b2152990fc59e19\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz\", \"integrity\": \"sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==\", \"time\": 0, \"size\": 5179, \"metadata\": {\"url\": \"https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6799e52a12dedc4a8cca2afd9ff0a0f444219aece66ac340a7aaf4c02923",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/6f"
@@ -4903,12 +4306,6 @@
         "contents": "28985d61bd4a882a1a7861c931e0fffbda065b6c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz\", \"integrity\": \"sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==\", \"time\": 0, \"size\": 6779, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "fefef5c06cc570a726f66b226d6abde231b9f5de2ae35354240c598b5518",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/17"
-    },
-    {
-        "type": "inline",
-        "contents": "28cacebe1561986b3a2fde5fdb95ddb549d5feed\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz\", \"integrity\": \"sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==\", \"time\": 0, \"size\": 2069, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d257ecec6d00dc68b2d319875d4742217f471094b1d6a1367a7f4bd8b76e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/a2"
     },
     {
         "type": "inline",
@@ -4936,12 +4333,6 @@
     },
     {
         "type": "inline",
-        "contents": "2a619d7fd0e468e5451e8db7968ca9118663a080\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz\", \"integrity\": \"sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==\", \"time\": 0, \"size\": 13172, \"metadata\": {\"url\": \"https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4743370e34e005b6cd4335cb859368712e4c25c10926f20b1d35c1985190",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/99"
-    },
-    {
-        "type": "inline",
         "contents": "2a66929a98d00add15f3f9651adccf72e8542b9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz\", \"integrity\": \"sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==\", \"time\": 0, \"size\": 5203, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "464a09af299a6607875146c73e357016c5cb1808f31cb066f94d226bc3dd",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/b7"
@@ -4963,12 +4354,6 @@
         "contents": "2bdf558ae872100445d39c9d6fac55b69312f3f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz\", \"integrity\": \"sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==\", \"time\": 0, \"size\": 5596, \"metadata\": {\"url\": \"https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c5ae5884dcf7678189db49acdbd1fee0fdb92a113a81dc0e2caf59f11279",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a2/b2"
-    },
-    {
-        "type": "inline",
-        "contents": "2bff4172f3ec4ff4558dc793425ad447b9e51cae\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz\", \"integrity\": \"sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==\", \"time\": 0, \"size\": 4179, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3efdb49ec793edec421447226bed140a11e6cc5cdabd97afa460b94bb240",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/a4"
     },
     {
         "type": "inline",
@@ -4996,15 +4381,27 @@
     },
     {
         "type": "inline",
-        "contents": "2f4617b7a45443c49708a63afa04137838437d02\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz\", \"integrity\": \"sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==\", \"time\": 0, \"size\": 3335, \"metadata\": {\"url\": \"https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "43090c258fd9a2441187f33cf80bf1bfaea5e3a9700be43d01de08f72b48",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/46"
+        "contents": "2dbe681aae7b3a241b7796c780146bec20550fce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz\", \"integrity\": \"sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==\", \"time\": 0, \"size\": 15150, \"metadata\": {\"url\": \"https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "71530670bce6bf68e2bacb7d97b198b5893b9d2740e581be41865d6f6122",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/13/a0"
+    },
+    {
+        "type": "inline",
+        "contents": "2f95fb9873cbda234570f8f36deb1db482329a85\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz\", \"integrity\": \"sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==\", \"time\": 0, \"size\": 1617, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1c3e76a8df00bf153dfbbc5e47ad20b4fd3a4948ba07e2985c87e223d3d1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/d3"
     },
     {
         "type": "inline",
         "contents": "315cdcff020394ba4f89097b1d16ca4045952b16\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz\", \"integrity\": \"sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==\", \"time\": 0, \"size\": 29670, \"metadata\": {\"url\": \"https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "cbfd4d2efb2b258390626a7e16c723c9c81de82bdbff8a0c68ad16c8d56c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/2d"
+    },
+    {
+        "type": "inline",
+        "contents": "31d703f29e5606eea08472d40230d88960e37d90\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz\", \"integrity\": \"sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==\", \"time\": 0, \"size\": 2502, \"metadata\": {\"url\": \"https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b017428277309aa84f5cdfac20dec873ee9f5ac2f26681e221687459e54",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/f5"
     },
     {
         "type": "inline",
@@ -5056,15 +4453,15 @@
     },
     {
         "type": "inline",
-        "contents": "36ef8d138bb98df529da9b6fa9a0895ec878bccd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz\", \"integrity\": \"sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==\", \"time\": 0, \"size\": 1071, \"metadata\": {\"url\": \"https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d267c1b7fb7fae7f65545be923fd601760b059024349c393e4ee068084ab",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/bd"
+        "contents": "36c4fe1399465b47650740326a1558875386fa83\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz\", \"integrity\": \"sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==\", \"time\": 0, \"size\": 3898, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6e9daf2d00b356e2538a460cb0a939beb9a42f0c2d08929262ae718b6517",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/66/d8"
     },
     {
         "type": "inline",
-        "contents": "3792ec3f716db019a322b927460df98d641d1f0b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz\", \"integrity\": \"sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==\", \"time\": 0, \"size\": 1969, \"metadata\": {\"url\": \"https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "75bf8643b1d803f427bd1e39480195432a26cf1b842251ec3a8629bd85b9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/00"
+        "contents": "36ef8d138bb98df529da9b6fa9a0895ec878bccd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz\", \"integrity\": \"sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==\", \"time\": 0, \"size\": 1071, \"metadata\": {\"url\": \"https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d267c1b7fb7fae7f65545be923fd601760b059024349c393e4ee068084ab",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/bd"
     },
     {
         "type": "inline",
@@ -5098,6 +4495,12 @@
     },
     {
         "type": "inline",
+        "contents": "38bcecd4c9f99925ba7dd6e465f0fa50e77bb3f8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.0.12.tgz\", \"integrity\": \"sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==\", \"time\": 0, \"size\": 86622, \"metadata\": {\"url\": \"https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.0.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b95398abbfdbf0d792ab61d979e0dc3c01a49e28c14763e60def45faff04",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/06"
+    },
+    {
+        "type": "inline",
         "contents": "38f268f5244e21bb05f777c9975d604e78345db9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz\", \"integrity\": \"sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==\", \"time\": 0, \"size\": 7516, \"metadata\": {\"url\": \"https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c5a8a9e717c101f71312232233a70e00b36a3e50883aa25242b453f4033a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/c7"
@@ -5107,6 +4510,12 @@
         "contents": "3a335be62977bd5c9773c7e41da25d1a6a47cc3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz\", \"integrity\": \"sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==\", \"time\": 0, \"size\": 28613, \"metadata\": {\"url\": \"https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "b41f4759346e1d3b6651322d78c7983a4a546cdd6c18c3eb56c944571e4b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/aa"
+    },
+    {
+        "type": "inline",
+        "contents": "3a52d4a49e8643ee64dc1d64a179fab16675f383\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz\", \"integrity\": \"sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==\", \"time\": 0, \"size\": 3197, \"metadata\": {\"url\": \"https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5be13ac59f1d5c5507a6a130f88888a17fea9d845019a4e970627efc05fb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/5b"
     },
     {
         "type": "inline",
@@ -5122,6 +4531,12 @@
     },
     {
         "type": "inline",
+        "contents": "3ba94d414b4f205dc2f2b607d8ad921e91c20bde\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-5.7.2.tgz\", \"integrity\": \"sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==\", \"time\": 0, \"size\": 17872, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-5.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "326bbe3e88c981f3f2700e89f091f4f912cf110ae44023316ea62051848d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/7c"
+    },
+    {
+        "type": "inline",
         "contents": "3bd257e336bd122dc2b3e7d617d2f9627fa72e3d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz\", \"integrity\": \"sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==\", \"time\": 0, \"size\": 2552, \"metadata\": {\"url\": \"https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "367acc572c1c8511d78b8bb723ba67429c954e7281592c8a833a52882080",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/c3"
@@ -5134,21 +4549,9 @@
     },
     {
         "type": "inline",
-        "contents": "3c03afe5ef0a1c06ca73e6e800bb95d4b58ed074\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz\", \"integrity\": \"sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==\", \"time\": 0, \"size\": 3642, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1e016c36eb2f718790981ec52c316c2b4fbed6ef8e6fff364130e9969656",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/b5"
-    },
-    {
-        "type": "inline",
         "contents": "3c7deb99f838a3f9534d42b004e59772d0d59e44\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jake/-/jake-10.9.2.tgz\", \"integrity\": \"sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==\", \"time\": 0, \"size\": 40697, \"metadata\": {\"url\": \"https://registry.npmjs.org/jake/-/jake-10.9.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "1045fbdd0474cca686aed4ac86687a6ffba4f5e237785a981d8af239a3b6",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/7a/98"
-    },
-    {
-        "type": "inline",
-        "contents": "3c92e8746c4f508458a8978adb59d58030c6b2da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.0.tgz\", \"integrity\": \"sha512-KHBC7z61OJeaMGnF3wqNZj+GGNXOyypZviiKpQeiHirG5Ib1ImwcLBH70rbMSkKfSmUNBsdf2PwaEJtKvgmkNw==\", \"time\": 0, \"size\": 3205, \"metadata\": {\"url\": \"https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "bbd8108d264e2889f49f17c33e8f1d02b397f809a4b535de3b0d4f108d73",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/f2"
     },
     {
         "type": "inline",
@@ -5164,9 +4567,9 @@
     },
     {
         "type": "inline",
-        "contents": "3cc7f66092d79e1d5e2f8918318504c01389ac1a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz\", \"integrity\": \"sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==\", \"time\": 0, \"size\": 1965, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6e67588d4b35e5f5838749213882b57aaf03d69aef673ed5dfd9369eebb7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/57"
+        "contents": "3cc2398b66eb00e75751d95feb070a2505f9e68f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz\", \"integrity\": \"sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==\", \"time\": 0, \"size\": 4159, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7ffbfc49f5bb178314f8c9183897272874c332c41198812df7db4335f724",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/0d"
     },
     {
         "type": "inline",
@@ -5182,21 +4585,15 @@
     },
     {
         "type": "inline",
-        "contents": "3d0bac38461672beba3828a29592f568fc20d8b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz\", \"integrity\": \"sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==\", \"time\": 0, \"size\": 8802, \"metadata\": {\"url\": \"https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0c2af484c5d3b99e723c27137040aa439f9d663f01f06132c70cf21a3a12",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8b/65"
+        "contents": "3d2261ffa4cc548b017596cf3d9fced59df7a038\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz\", \"integrity\": \"sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==\", \"time\": 0, \"size\": 3700, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "63f3fcd60dcd951e3e9797d63c80891dea050f6efd867e00fe26a5a51a0c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/d6"
     },
     {
         "type": "inline",
         "contents": "3d4f5fc6050f859d9f031edcce2a0d18cfc12367\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz\", \"integrity\": \"sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==\", \"time\": 0, \"size\": 30780, \"metadata\": {\"url\": \"https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "40a69f5de319f5e3f35766e3a82b303c1b01eab867f9d987f996dc8e1e29",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/80/dd"
-    },
-    {
-        "type": "inline",
-        "contents": "3dae037184ae26ef188d247ee8ae6c9fad4b42a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/read/-/read-19.8.0.tgz\", \"integrity\": \"sha512-6ywxOGYajcxK1y1MfzrOnwsXO6nnErna88gRWEl3qqOOP8MDu/DTeRkGLXBFIZuRZ7mm5yyxU5BmeUvMpNte5w==\", \"time\": 0, \"size\": 4975, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/read/-/read-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ecc0a43ceeb47d6104b5213250cc632c399ac124fdc3982792850fefd9ac",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/89"
     },
     {
         "type": "inline",
@@ -5212,21 +4609,15 @@
     },
     {
         "type": "inline",
-        "contents": "3e90ae4d5fd6077be903ac36a180f20382029b10\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz\", \"integrity\": \"sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==\", \"time\": 0, \"size\": 5052, \"metadata\": {\"url\": \"https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6189df0792aa97c0ff62a3061969d948332c3ee59c2f5a1f48e473406b43",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/84"
-    },
-    {
-        "type": "inline",
         "contents": "3ea6b966ee10069b1961661a404afa063661ddee\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz\", \"integrity\": \"sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==\", \"time\": 0, \"size\": 14302, \"metadata\": {\"url\": \"https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d1c28b5fa917c3cfa94e3e87dab62fdc953e07fe93e0a3ecab080f58be93",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/43"
     },
     {
         "type": "inline",
-        "contents": "3fc8834d4c255f1a0983e94917c4fa3ca7cd7dcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/listr2/-/listr2-8.2.5.tgz\", \"integrity\": \"sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==\", \"time\": 0, \"size\": 56812, \"metadata\": {\"url\": \"https://registry.npmjs.org/listr2/-/listr2-8.2.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2bfa0f4951c67025c0c9de033135b5f40be9756d924feca8e2f37266699c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/c5"
+        "contents": "404631371bc60fc5d707e0ffaf61fe52063a5ae5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz\", \"integrity\": \"sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==\", \"time\": 0, \"size\": 1405830, \"metadata\": {\"url\": \"https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b559813de222517cdc12c45caa1fb240556f92e0352186fda7288d31cfb8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/aa"
     },
     {
         "type": "inline",
@@ -5245,6 +4636,12 @@
         "contents": "41f4d4236c1b6098038409c0bddc1eaa6b3fbcd1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz\", \"integrity\": \"sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==\", \"time\": 0, \"size\": 17376, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d9def0c06c05a04a8bd9bba7f2a342b1a6bfbc66079b753ef7353e657994",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/5c"
+    },
+    {
+        "type": "inline",
+        "contents": "425422f1a71860fc3a93e55c42fc8551bb50ae14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz\", \"integrity\": \"sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==\", \"time\": 0, \"size\": 4565, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5361d0856bb86b5b5d43dcaddaf0f295671075420bfeff72abe38a682b84",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/85"
     },
     {
         "type": "inline",
@@ -5272,12 +4669,6 @@
     },
     {
         "type": "inline",
-        "contents": "4314c8636ac993a9878299f668aa6aacece59b72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz\", \"integrity\": \"sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==\", \"time\": 0, \"size\": 2347, \"metadata\": {\"url\": \"https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "04e6f64d657039df04ffd17af0bb8c7b3f5db2f8937c8a322ae2455af62e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/8f"
-    },
-    {
-        "type": "inline",
         "contents": "443377582687c1fe1f77f7b2103e349ed7be2fab\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz\", \"integrity\": \"sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==\", \"time\": 0, \"size\": 143727, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "40d05a0809760934aebff4c68bc3fd6fb716050dc3e9d5db8756b58a6015",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/b6"
@@ -5290,15 +4681,21 @@
     },
     {
         "type": "inline",
-        "contents": "46431b344946b3704ba1bd2ac6976e7eb1416816\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.0.tgz\", \"integrity\": \"sha512-IZ5IE90h6DSWNuNK/cwjABLAKdy8tP8OgGVGbXe1noBEX5hSsu00uRlLu6JuruiXjWJz2dZc+YSw3H0UZyl/mA==\", \"time\": 0, \"size\": 13330, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6766f797f01f960467e4743b2e1d3e7d3c18f7f023d69863488e56fad1bf",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/73"
+        "contents": "44cd0b1b3bb58b3f65c1feda85642adfabb22c1c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz\", \"integrity\": \"sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==\", \"time\": 0, \"size\": 5537, \"metadata\": {\"url\": \"https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "407397fb4d570f9126e6ba00bd4221d5f1c2544480fc89a28fab37df52b8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/b3"
     },
     {
         "type": "inline",
-        "contents": "4653d13f0994aeadd490043ebc7e82954852a05d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz\", \"integrity\": \"sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==\", \"time\": 0, \"size\": 2733, \"metadata\": {\"url\": \"https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2f1edd4373313cbd899bdfb10fa0acdf376a25dd5eabb8cac8170302cdb8",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/f0"
+        "contents": "44ce4e4997076de4c6af6ba65632c09c7ce9b333\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/socks/-/socks-2.8.4.tgz\", \"integrity\": \"sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==\", \"time\": 0, \"size\": 29861, \"metadata\": {\"url\": \"https://registry.npmjs.org/socks/-/socks-2.8.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ff961c214e8eefb28323e6825f9f1ed4c15b6330bd61fd93ec5c250b8f32",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/f6"
+    },
+    {
+        "type": "inline",
+        "contents": "45d26e75eaf9c331b27d6ffcc0754fe8fb1793ab\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz\", \"integrity\": \"sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==\", \"time\": 0, \"size\": 4688, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "13c8727e152bf1db25d97323c55612f647fa12e22c8859acfa5706cac99b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/15"
     },
     {
         "type": "inline",
@@ -5314,15 +4711,15 @@
     },
     {
         "type": "inline",
-        "contents": "4843b9c2ac1f980ddf51fc31f009a1e3c754b513\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz\", \"integrity\": \"sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==\", \"time\": 0, \"size\": 14174, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "65656f36ea48a154b1f251935b020198b817263e94240cb6944a03ca3ba1",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/1a"
-    },
-    {
-        "type": "inline",
         "contents": "484ec40eaff6c9c268b9bb5f40857de615c2c328\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz\", \"integrity\": \"sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==\", \"time\": 0, \"size\": 8956, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d1bf7deb7e9b36e35eef37d24da7f580570ee5d9a36217e4040e155ca3a5",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/30"
+    },
+    {
+        "type": "inline",
+        "contents": "48580bc02c16a4db4189562bd30ea49f6e087c15\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz\", \"integrity\": \"sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==\", \"time\": 0, \"size\": 2325, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f3866195f1ebf449d9f072bf20da3b72b85f5301ee4db2f12e8617e9c8c1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/43"
     },
     {
         "type": "inline",
@@ -5338,21 +4735,15 @@
     },
     {
         "type": "inline",
-        "contents": "4a123874435f1245d1c1e588214ffb2d8485699b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz\", \"integrity\": \"sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==\", \"time\": 0, \"size\": 3020, \"metadata\": {\"url\": \"https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b4d8ecef0ade0bb7e035d93835776116ac0ee816bdbc5f714bd1eec97ff6",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/4d"
+        "contents": "49eec6292d4561b11bd26e9fcd20167369357f49\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz\", \"integrity\": \"sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==\", \"time\": 0, \"size\": 72513352, \"metadata\": {\"url\": \"https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e0712ca33832a5861ca7bad3f7f23b647c9aecf2607163fdea714223bcd3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/46"
     },
     {
         "type": "inline",
         "contents": "4a368b82a8b2774c922ad4245dec40662ab77040\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz\", \"integrity\": \"sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==\", \"time\": 0, \"size\": 10811, \"metadata\": {\"url\": \"https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "fd58b097f40ddba63bdd216a122c04f09909fdcc4f35711a3a1802a09fd3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/4a"
-    },
-    {
-        "type": "inline",
-        "contents": "4a466bb401584de41206fcf25402ba8be4c795c1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz\", \"integrity\": \"sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==\", \"time\": 0, \"size\": 14715, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3085bdf9e286bcb0302a2aeaa0d9a991c002c5beec68c57d7b6f24a7c568",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/30"
     },
     {
         "type": "inline",
@@ -5374,12 +4765,6 @@
     },
     {
         "type": "inline",
-        "contents": "4b84e4e71afcdd55b4c3c2b72bc752fe05ace7f6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/asar/-/asar-3.2.14.tgz\", \"integrity\": \"sha512-hc52QkesULqbxTRC1vOmSBN1YndUkieoNMfvpe988h0MEoGGqbijkOqv4/2M9PufBJxiTVoDdBmBFfXPowZDQg==\", \"time\": 0, \"size\": 20981, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/asar/-/asar-3.2.14.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "083aaa439fdfbfd08cf61bf6ba81908e1822e9d2020ce9e62084e3c9585d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e2/87"
-    },
-    {
-        "type": "inline",
         "contents": "4ca1dc5968526e4aac494fc8f65c48a048f44e5f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/got/-/got-11.8.6.tgz\", \"integrity\": \"sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==\", \"time\": 0, \"size\": 67729, \"metadata\": {\"url\": \"https://registry.npmjs.org/got/-/got-11.8.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e08f3dfa5d00cabec76b3a947effc9e3d49e62b94e985db850a84c753e5d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/11"
@@ -5398,21 +4783,15 @@
     },
     {
         "type": "inline",
-        "contents": "4d87fa2d43b1f79fe874f625be51b1ef6555204f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz\", \"integrity\": \"sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==\", \"time\": 0, \"size\": 2696, \"metadata\": {\"url\": \"https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "560a88b4bb3cf23a51b288e28f388f9139ae56910fba9c09cdd6565e0138",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/55"
+        "contents": "4dab0aa9ca311513061e53ab0c92af96a0686dda\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron/-/electron-36.2.1.tgz\", \"integrity\": \"sha512-mm1Y+Ms46xcOTA69h8hpqfX392HfV4lga9aEkYkd/Syx1JBStvcACOIouCgGrnZpxNZPVS1jM8NTcMkNjuK6BQ==\", \"time\": 0, \"size\": 176466, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron/-/electron-36.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "91113f41b2f137a4deacf4958045541e5e8587c86ab0d80005d70aa8a52f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0e/71"
     },
     {
         "type": "inline",
         "contents": "4e40e703b6cecd2cafa74bfa6095e001074c9f9b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globals/-/globals-14.0.0.tgz\", \"integrity\": \"sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==\", \"time\": 0, \"size\": 17235, \"metadata\": {\"url\": \"https://registry.npmjs.org/globals/-/globals-14.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "aa8a49a64aa50b6965e5452104c55b9f97fec3e5c280a171bbc0021410e3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/3e"
-    },
-    {
-        "type": "inline",
-        "contents": "4e86a1778ec55a392ed900a4484ab6e68c6fac06\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/send/-/send-1.2.0.tgz\", \"integrity\": \"sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==\", \"time\": 0, \"size\": 14661, \"metadata\": {\"url\": \"https://registry.npmjs.org/send/-/send-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f730f43854330aa49f4e2de566455ba625f5769d842dffbad6822775d64a",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/74"
     },
     {
         "type": "inline",
@@ -5446,21 +4825,9 @@
     },
     {
         "type": "inline",
-        "contents": "50e3a058a326133a8c0acabd137091e720a115be\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.0.tgz\", \"integrity\": \"sha512-YNIKAc4EXvNeAvyeEnzgvm1VyAe0/b3Wax7pjJSwXuhqIQ1/t2hD3OYRXb6D5/GffIvaX82RbjD+nWtMZCLL7Q==\", \"time\": 0, \"size\": 2333, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1a8eb54463f8870fc66b106e05554cab29cea793cc64b2ab16287afc675e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/42"
-    },
-    {
-        "type": "inline",
         "contents": "5148e76a98ebca0061a0013fe83122bbdd2b0636\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/async/-/async-3.2.6.tgz\", \"integrity\": \"sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==\", \"time\": 0, \"size\": 150393, \"metadata\": {\"url\": \"https://registry.npmjs.org/async/-/async-3.2.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2ef4d8877589473848fd9bf548c44e0a4b9e0b52f57d138c51b77a9fe6c8",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/2d"
-    },
-    {
-        "type": "inline",
-        "contents": "514d4083db51fa59feebadb1a7979c47b8ffbee6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz\", \"integrity\": \"sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==\", \"time\": 0, \"size\": 6702, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8cb5f456bd9dc0f65e785dbc8d31bb2f694741f4e29d52b74029622e8c32",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/51"
     },
     {
         "type": "inline",
@@ -5479,12 +4846,6 @@
         "contents": "51b19b70248d565674a59683739d10bb662dc675\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz\", \"integrity\": \"sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==\", \"time\": 0, \"size\": 162341, \"metadata\": {\"url\": \"https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "46aa10b993a127cbbc204dbee6d04cba50cf89ef5548269c22d89e4ec6bd",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/43/77"
-    },
-    {
-        "type": "inline",
-        "contents": "51d950ec5bbad342d3f4aaa191c6bacf920989b9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz\", \"integrity\": \"sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==\", \"time\": 0, \"size\": 6339, \"metadata\": {\"url\": \"https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f632285e771b108e41613ffc8b0fae92e0b1fcb5c963af58c849bb86badd",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/d8"
     },
     {
         "type": "inline",
@@ -5530,12 +4891,6 @@
     },
     {
         "type": "inline",
-        "contents": "54fc36a2b9798253c84aed8ebe3bc76602ce420d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/router/-/router-2.2.0.tgz\", \"integrity\": \"sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==\", \"time\": 0, \"size\": 14251, \"metadata\": {\"url\": \"https://registry.npmjs.org/router/-/router-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f4ddf7c86f3268df4a98b0fbdfc41a3b47b2c1e83a46c65410bdd1f9660d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/0f"
-    },
-    {
-        "type": "inline",
         "contents": "55dc518ad4ed2a09b7c89ca41ae70c63b34d4aeb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz\", \"integrity\": \"sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==\", \"time\": 0, \"size\": 2313, \"metadata\": {\"url\": \"https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6fe07a61a892f6f6531a5c2b91b04027042da092d88fd7fc49eea54646d0",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/49/eb"
@@ -5545,6 +4900,18 @@
         "contents": "5631bc8360c25b8f2f6065c37610aef3d1fb69f3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz\", \"integrity\": \"sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==\", \"time\": 0, \"size\": 4683, \"metadata\": {\"url\": \"https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9b1b5aa5889844cd472441c0c1f23172a8dfb7c90ff4d55a8de845646955",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/9e"
+    },
+    {
+        "type": "inline",
+        "contents": "56c86c40022773c5550a2adf93ccd9b0b040aebc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz\", \"integrity\": \"sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==\", \"time\": 0, \"size\": 619559, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1c231091054aa101949d3f7dd5f67ad47d988ae91f58cf08325e704c5ae5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/22"
+    },
+    {
+        "type": "inline",
+        "contents": "56d44fe3f3ed4558eae56c620b7053f928696bc5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.0.12.tgz\", \"integrity\": \"sha512-+/CEPH1fVKf6HowBUs6LcAIoRcjeqgvAeoSE+cl7Y7LndyQ9ViGPYibNk7wmhMHzNgHIuIbw4nWADPO+4mjgWw==\", \"time\": 0, \"size\": 1002987, \"metadata\": {\"url\": \"https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.0.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "02b4fbcfcd7b1afb8dc377c2214d0896c05010afeaa9ac285fc2a170813b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/93/bf"
     },
     {
         "type": "inline",
@@ -5572,12 +4939,6 @@
     },
     {
         "type": "inline",
-        "contents": "5863969a767d3fce84ba03bfd28e4abbd88f93f6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/qs/-/qs-6.14.0.tgz\", \"integrity\": \"sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==\", \"time\": 0, \"size\": 58040, \"metadata\": {\"url\": \"https://registry.npmjs.org/qs/-/qs-6.14.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "31c9c48635fb47969a293eba4f565d970b8b2dd86e021ae1713753ddbaec",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/bc"
-    },
-    {
-        "type": "inline",
         "contents": "58a0b59460b121f337b61fbfc2d37546f47c64e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz\", \"integrity\": \"sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==\", \"time\": 0, \"size\": 9678, \"metadata\": {\"url\": \"https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7e7b8522a3b6a9b4f14b1c7650e317761369d5ebc7e6afa5c7e2979b87f",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/b1"
@@ -5593,18 +4954,6 @@
         "contents": "596d0838d69d40374d1e68327b7ffef20ada0390\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz\", \"integrity\": \"sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==\", \"time\": 0, \"size\": 2383, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "489c0e6a9e4cbd64a8acd4fbfda113e9dfdd114f464830471fda53fff0cd",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/c4"
-    },
-    {
-        "type": "inline",
-        "contents": "599dcb93f14c4dd78d5702313f2870730c3c0d6f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz\", \"integrity\": \"sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==\", \"time\": 0, \"size\": 6820, \"metadata\": {\"url\": \"https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "be3d016785d0d2cec4db2c5d819f13c823a98b0b9e0cf6a8cb1227f49f46",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/91/7d"
-    },
-    {
-        "type": "inline",
-        "contents": "59b3793089a7ffc915399b9b37856c79b865b6db\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/verror/-/verror-1.10.10.tgz\", \"integrity\": \"sha512-l4MM0Jppn18hb9xmM6wwD1uTdShpf9Pn80aXTStnK1C94gtPvJcV2FrDmbOQUAQfJ1cKZHktkQUDwEqaAKXMMg==\", \"time\": 0, \"size\": 2512, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/verror/-/verror-1.10.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3566db5ab32a9c07496acfa437f7157884ad48d9b5b195ec8315d5042d57",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/07/1d"
     },
     {
         "type": "inline",
@@ -5644,18 +4993,6 @@
     },
     {
         "type": "inline",
-        "contents": "5b7cf93a8fb7517665f6b83ecb325da73fa55e0a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz\", \"integrity\": \"sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==\", \"time\": 0, \"size\": 8059, \"metadata\": {\"url\": \"https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0f71af664e01a2bcdb74e9ab0900d054d8d5e3c71145b194020417d23400",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/d2"
-    },
-    {
-        "type": "inline",
-        "contents": "5bad7a76958185083f46cc0bdd76460e315306b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz\", \"integrity\": \"sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==\", \"time\": 0, \"size\": 7797, \"metadata\": {\"url\": \"https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "16536ac4cc96094a70d9fa7fb88a53417593bd7bbeadd3a790b1929c0321",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/9c"
-    },
-    {
-        "type": "inline",
         "contents": "5c63a4fd69e2dfae0ff74c658006785d3bbf1e67\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz\", \"integrity\": \"sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==\", \"time\": 0, \"size\": 21539, \"metadata\": {\"url\": \"https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ec19eb6f134ac8def05a2b0cb2dce598ac837ee5d56b3ff20d9a8844a39c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/18"
@@ -5692,9 +5029,9 @@
     },
     {
         "type": "inline",
-        "contents": "5ef2f7b8d3245158396643ab56dcaf030c9c2a45\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz\", \"integrity\": \"sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==\", \"time\": 0, \"size\": 4683, \"metadata\": {\"url\": \"https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b686f5763e873c7ac89f736fdb9f670e8ab18e6660dd6285d0b13f70a2a2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/a8"
+        "contents": "5fd87adcc0d436274acdbc3d797fce97e608fda3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz\", \"integrity\": \"sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==\", \"time\": 0, \"size\": 16283, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3a9821f7acadbeaf3cd6f7eca048aca0b1fe0fd3e1d443d50fde0fbb8c6a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/41"
     },
     {
         "type": "inline",
@@ -5704,9 +5041,27 @@
     },
     {
         "type": "inline",
+        "contents": "608d480550c58cd47b0d3592dae8b4c13a304f1d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz\", \"integrity\": \"sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==\", \"time\": 0, \"size\": 11310, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e248382bd2c662a87dd95dcaddfacc26f80a076266156b7529cf5ba4aa4c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0e/54"
+    },
+    {
+        "type": "inline",
+        "contents": "6191f9d18ed97025229b2118d755a783cc4c9186\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz\", \"integrity\": \"sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==\", \"time\": 0, \"size\": 15474, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "db352e186cbce6b60b1975daab00b0615c958ef3d108371d87511a427cb7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/bd"
+    },
+    {
+        "type": "inline",
         "contents": "62fc2f09977ec3ec2f3b218de1da6948b5ef56a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz\", \"integrity\": \"sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==\", \"time\": 0, \"size\": 3265, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e05e41ce38b1de47d720428a14c9b0c12d84930460e815e4b4e08ee724d5",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/00"
+    },
+    {
+        "type": "inline",
+        "contents": "634c86eb52ae5b3308789a753cb496e7922865eb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/temp/-/temp-0.9.4.tgz\", \"integrity\": \"sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==\", \"time\": 0, \"size\": 5744, \"metadata\": {\"url\": \"https://registry.npmjs.org/temp/-/temp-0.9.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4084b4199df6728727c8c1ef60479569196173bfac5d2548c005d6fdf19d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/15"
     },
     {
         "type": "inline",
@@ -5734,12 +5089,6 @@
     },
     {
         "type": "inline",
-        "contents": "6418d4ddd22bfa2ccd429675aeed4ad22c092d92\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.0.tgz\", \"integrity\": \"sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==\", \"time\": 0, \"size\": 27935, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "498b206884d8336899ebc5a7d943f46a373f2000fe8323278a45a380648f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b8/6a"
-    },
-    {
-        "type": "inline",
         "contents": "6420abbda29f6dccd60d0ffd4b2bfc0dfc9beb88\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz\", \"integrity\": \"sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==\", \"time\": 0, \"size\": 2062, \"metadata\": {\"url\": \"https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f0eb0008c2ea8c5ecdde4102aed36dc4705d1aed3885538e5a1ee15644a7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/44/a8"
@@ -5752,12 +5101,6 @@
     },
     {
         "type": "inline",
-        "contents": "64c7a3a0f94b9bddc92702fa72506dfaf25a7cc3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz\", \"integrity\": \"sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==\", \"time\": 0, \"size\": 1654, \"metadata\": {\"url\": \"https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2407adde9d05bdd552950df201bc4af8db37f56e8a766823f9a3893a2107",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/fb"
-    },
-    {
-        "type": "inline",
         "contents": "6517f39b21e46514f6a3882938a842237a854702\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/environment/-/environment-1.1.0.tgz\", \"integrity\": \"sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==\", \"time\": 0, \"size\": 2766, \"metadata\": {\"url\": \"https://registry.npmjs.org/environment/-/environment-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "8e7ff11dd0fe25b7d40c7f2721c5c2d99d60b0990695b20923170f8eec18",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/e1/87"
@@ -5767,12 +5110,6 @@
         "contents": "6520cc209e4043bd45b276ef4ea46de092057728\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz\", \"integrity\": \"sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==\", \"time\": 0, \"size\": 6157, \"metadata\": {\"url\": \"https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "a5acf52705a1beb66603196f4bc44e583052d0f1d5a23dfb5316da1811d3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/d7"
-    },
-    {
-        "type": "inline",
-        "contents": "66301fe5916e47fef23f150f97b4d91ea4e55965\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz\", \"integrity\": \"sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==\", \"time\": 0, \"size\": 5442, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f306f68eac58ac50c3a0a0453cb8f29d78b9505c01947c965b4768a4e60d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/98"
     },
     {
         "type": "inline",
@@ -5806,12 +5143,6 @@
     },
     {
         "type": "inline",
-        "contents": "68d68d20d2f29d41fd71c9471fb7cb479530c465\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz\", \"integrity\": \"sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==\", \"time\": 0, \"size\": 8650, \"metadata\": {\"url\": \"https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d3fd3e46a163f82fdd731ab75931fed1c37113cd17537f776460af209acd",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/c3"
-    },
-    {
-        "type": "inline",
         "contents": "68f564140c592c4f1e64586672d73993310c8c32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz\", \"integrity\": \"sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==\", \"time\": 0, \"size\": 1894, \"metadata\": {\"url\": \"https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "393eb6f1cdd50a93cb92ed56af16a93821a9263f732f369d831c48199a58",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/c1"
@@ -5824,6 +5155,12 @@
     },
     {
         "type": "inline",
+        "contents": "698acc5ea92601afc1253ab15a689214acaf12ae\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz\", \"integrity\": \"sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==\", \"time\": 0, \"size\": 111694, \"metadata\": {\"url\": \"https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7659beb558bc3ef5fb360f7e5f3215a9d07bef572efd36f8f50b82fbadac",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/02"
+    },
+    {
+        "type": "inline",
         "contents": "6a9b5770720a4d6e733745e55ed124f9e8dc51cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz\", \"integrity\": \"sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==\", \"time\": 0, \"size\": 1684, \"metadata\": {\"url\": \"https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "8d77072374a0022204f7ed0c1aa73ee351cb74e16430f44d44f29b0cd918",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/11"
@@ -5833,12 +5170,6 @@
         "contents": "6ac447fe063513fbf45b75d1aaba8a1c90313486\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz\", \"integrity\": \"sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==\", \"time\": 0, \"size\": 2855, \"metadata\": {\"url\": \"https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c2e7373f9594d7feb21999f6846711aeb9007806a3ba7ccf8a811e061f6d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/2b"
-    },
-    {
-        "type": "inline",
-        "contents": "6adbaba62ba400aac19ad681117b1535e6c29374\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lucide-static/-/lucide-static-0.508.0.tgz\", \"integrity\": \"sha512-YflTbhlhtDxgxo/4dEOJ33TbBYBTdRgVKdL75Vpn4pm2kHNE96ZV4tHfNz0+2iL4SI4Ta+ES2J+dpBdX5UtN/g==\", \"time\": 0, \"size\": 5106109, \"metadata\": {\"url\": \"https://registry.npmjs.org/lucide-static/-/lucide-static-0.508.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e1117aaf5c1224535971e502767b4c05ac7e78c34200be28747eaa026103",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/62/d4"
     },
     {
         "type": "inline",
@@ -5884,15 +5215,15 @@
     },
     {
         "type": "inline",
-        "contents": "6dbb1c308588215c9cde640466654eb7f4eb3543\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/express/-/express-5.1.0.tgz\", \"integrity\": \"sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==\", \"time\": 0, \"size\": 52116, \"metadata\": {\"url\": \"https://registry.npmjs.org/express/-/express-5.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "dddbce622b996e5e9505ef6ffc327377392e2d0c78955994d8c8b1b6cc35",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/77"
-    },
-    {
-        "type": "inline",
         "contents": "6dd74ba36cad0b4c4397bcf3e07fffb0477ef93c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz\", \"integrity\": \"sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==\", \"time\": 0, \"size\": 2997, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "89a405526d28296d8f1f0e7bbafdd0c515a367d6169d6f70671a2bdf662e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/91/53"
+    },
+    {
+        "type": "inline",
+        "contents": "6df57237582143da9ce526cd28f13165bd95177c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz\", \"integrity\": \"sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==\", \"time\": 0, \"size\": 81182, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0d87c9f0d81b32d624b72d7cafe6f09adcf00a997a64532754c6a57902a8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/31"
     },
     {
         "type": "inline",
@@ -5914,12 +5245,6 @@
     },
     {
         "type": "inline",
-        "contents": "6f7306fb8a7d703618b9d182a74041d83378aad1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz\", \"integrity\": \"sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==\", \"time\": 0, \"size\": 36931, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "21307b8648ccb59369a047099eeeea0d6570ce5c6e1a6f8a085457d7b258",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/4c"
-    },
-    {
-        "type": "inline",
         "contents": "6f8f304b41febea546791ed65e7e29d3f60c0766\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob/-/glob-8.1.0.tgz\", \"integrity\": \"sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==\", \"time\": 0, \"size\": 15721, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob/-/glob-8.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e962cf0b88d9bc8d2867b787004a14cec59684fb56aeee17503cd84bb76f",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/26"
@@ -5929,12 +5254,6 @@
         "contents": "6fd8c9fd05891d4503a9d1422f58af31c33e8886\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/verror/-/verror-1.10.1.tgz\", \"integrity\": \"sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==\", \"time\": 0, \"size\": 12165, \"metadata\": {\"url\": \"https://registry.npmjs.org/verror/-/verror-1.10.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d9fc26bbcb7f0d38511edac0ccf198e19a8ab1c6ead330b4e6c1c014fb3f",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/ad"
-    },
-    {
-        "type": "inline",
-        "contents": "7004081edb8c44356406ef17d178015d41930534\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.0.tgz\", \"integrity\": \"sha512-fuLeI+EZ9x2v/+TXKAjplBJWI9CNrHnyi5nvUQGQt4WRkww/d95oVRsc9ajpt4xFrFmqMZkd/xBQHZDvALIY7A==\", \"time\": 0, \"size\": 1959, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "379657f6fb2d82de4f3d5dc1158304ea5596d5986cea58bed862876d231d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/34"
     },
     {
         "type": "inline",
@@ -5950,15 +5269,9 @@
     },
     {
         "type": "inline",
-        "contents": "718d32b8b782cfc8886c5f689e3e766c74fc2e25\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz\", \"integrity\": \"sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==\", \"time\": 0, \"size\": 955574, \"metadata\": {\"url\": \"https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "db8d367357bdb2a2eaa4d66ddd291adf7f152c14df0d0a5e960b2595c527",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a9/f0"
-    },
-    {
-        "type": "inline",
-        "contents": "71ce8e1ad93a8ebd5617348469a3149ae2864652\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz\", \"integrity\": \"sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==\", \"time\": 0, \"size\": 256650, \"metadata\": {\"url\": \"https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0cf723c90aba1212faf003fc9d6a2d825c42ef899a4f2123450615c14416",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b8/0c"
+        "contents": "716d80a029a950837f4392c933524e87d409cdd2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz\", \"integrity\": \"sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==\", \"time\": 0, \"size\": 17211, \"metadata\": {\"url\": \"https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "86210fc8a5e74d0b79cb6991d3fb68ef8a129409351dcb472a0aeb1eec74",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/59"
     },
     {
         "type": "inline",
@@ -5968,27 +5281,15 @@
     },
     {
         "type": "inline",
-        "contents": "73073d82ed6532456d298d65a32de037b042aaec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz\", \"integrity\": \"sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==\", \"time\": 0, \"size\": 13484, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "5493a3f63d08d73ce34a28fe62f40954bb8515c844bddc8d5cd5d91ecf58",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/09"
+        "contents": "722de3281d214095e31b0d75e919efe3d690b8dc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz\", \"integrity\": \"sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==\", \"time\": 0, \"size\": 1595, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2465e92e0d873fbc61c8d21a229481727824a514c8184757e1542e427f7d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/0a"
     },
     {
         "type": "inline",
         "contents": "73d4a2683087170c58fb20ce0a84ea68e0581bbb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz\", \"integrity\": \"sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==\", \"time\": 0, \"size\": 43198, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "17b36831b2882205700398c7aff0ec75838e8f7f2a57da712340b8ab7e46",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/87"
-    },
-    {
-        "type": "inline",
-        "contents": "741443603a9be1a77a33a32147658c7aaab554c8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz\", \"integrity\": \"sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==\", \"time\": 0, \"size\": 1994, \"metadata\": {\"url\": \"https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "bc6d0b4803fe1a45d363bbea15312e4bb176f694c3088f2410b575cf8a76",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a9/0e"
-    },
-    {
-        "type": "inline",
-        "contents": "747a0a79a29fdb1906eb0161e4c142a931d9b1c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/load/-/load-19.8.0.tgz\", \"integrity\": \"sha512-4rvmm3ff81Sfb+mcWT5WKlyOa+Hd33WSbirTVUer0wjS1Hv/Hzr07Uv1ULIV9DkimZKNyOwXn593c+h8lsDQPQ==\", \"time\": 0, \"size\": 11335, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/load/-/load-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a0b92e9b003524f53288f8c7bbfe249e2d07d920d8cade166676781ce24c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/68/e8"
     },
     {
         "type": "inline",
@@ -6058,27 +5359,21 @@
     },
     {
         "type": "inline",
-        "contents": "7920001fbe1f56f25ec45b0a78fcc6bf5f7ce1a1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz\", \"integrity\": \"sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==\", \"time\": 0, \"size\": 3320, \"metadata\": {\"url\": \"https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "19011784881f71ec55d5d091c7d1fd3236652c4e909eaf533047aed903a7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/2e"
-    },
-    {
-        "type": "inline",
-        "contents": "797608fcf93fde8df9a092652849aa43010560a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz\", \"integrity\": \"sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==\", \"time\": 0, \"size\": 2620, \"metadata\": {\"url\": \"https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "43709acce47af8e18110cbb03341c2873e282907f67302362bb5b4e1ed75",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/23"
-    },
-    {
-        "type": "inline",
         "contents": "797624f04b81f50c41a5caab0871aa78de08d36d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz\", \"integrity\": \"sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==\", \"time\": 0, \"size\": 2090, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e6c68d06ab7e38ec96cbf919523a6c676394845af37ebaa0d6acab82661c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/49/43"
     },
     {
         "type": "inline",
-        "contents": "79afd209a6bf2a1f634ae5d489034652e11dc127\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/etag/-/etag-1.8.1.tgz\", \"integrity\": \"sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==\", \"time\": 0, \"size\": 4386, \"metadata\": {\"url\": \"https://registry.npmjs.org/etag/-/etag-1.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1314e79200fca71af4663702ee1e676113e408ca8a468a396de5ab6d5d2b",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/ae"
+        "contents": "79df6aeacb3a61b65cca811e9740a8ab7b741819\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz\", \"integrity\": \"sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==\", \"time\": 0, \"size\": 2677, \"metadata\": {\"url\": \"https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b9e22026b9c7d32f01eebcaae1ba78a0c50fff9f6daa3c7fd8351e1f2f84",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "7a5332ed80674fb40d1d266cf912b83a81e92849\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz\", \"integrity\": \"sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==\", \"time\": 0, \"size\": 32085, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "78c6e4f62f566a7470892bcba249cb773218bc3396c274080f4fd8c8d691",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/0a"
     },
     {
         "type": "inline",
@@ -6094,12 +5389,6 @@
     },
     {
         "type": "inline",
-        "contents": "7b1405df3d8b3750ff16882401502a81c548e5b4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz\", \"integrity\": \"sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==\", \"time\": 0, \"size\": 1907, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "328b03b0512a86f7e81ba3dfd27b86fdb5be857957bbbe3ad3306625e207",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/ef"
-    },
-    {
-        "type": "inline",
         "contents": "7b2d747d618f46d1775b8eb768571f2e61b49b8f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz\", \"integrity\": \"sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==\", \"time\": 0, \"size\": 32117, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "26ca363cac530433a303cd6fdcde4960a2a672551432d072929d8c80ead8",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/ff"
@@ -6109,6 +5398,12 @@
         "contents": "7b77477d3ebf4ff7772fc1cfd24dd54ee02c3a52\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz\", \"integrity\": \"sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==\", \"time\": 0, \"size\": 6448, \"metadata\": {\"url\": \"https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6eb1286438e562ed6e7d5626fe7d1031e4d149c3c730b32c6cb90432f13c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/92"
+    },
+    {
+        "type": "inline",
+        "contents": "7be9a6398f02b699cab8f4c3b5cf1836c027777b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz\", \"integrity\": \"sha512-/AZHJL6F6B/G959CsMAzrPKKZjeEiAVifRyEwXxcT6qtqbPwGw+iQxmNS+Bu+i09OCtdNRW6pNpBvgPrtMr9EQ==\", \"time\": 0, \"size\": 4703, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0312151478f4ada07f45d5fd45d03ccd2497037b4289e2a245191a2fd40a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/35"
     },
     {
         "type": "inline",
@@ -6136,21 +5431,9 @@
     },
     {
         "type": "inline",
-        "contents": "7c67ccfc3aa72d9912e2b63d36dbaa242d50a1fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.0.tgz\", \"integrity\": \"sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==\", \"time\": 0, \"size\": 4564, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "7d106ecda7873ebb6332b2373b996f3a2db5ef9334521446409ba3fe0498",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/76"
-    },
-    {
-        "type": "inline",
         "contents": "7ca1aaff10735a730d04e84a69646d25e5c28145\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz\", \"integrity\": \"sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==\", \"time\": 0, \"size\": 26992, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "53e431efe5d40277f768cec075f9e7f618f2296715654a7b953121078b1e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/14"
-    },
-    {
-        "type": "inline",
-        "contents": "7d21717c4e567545f83ac76049c2266b5a7ad75e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz\", \"integrity\": \"sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==\", \"time\": 0, \"size\": 3691, \"metadata\": {\"url\": \"https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "7cafca031752a10b71541c70fbccaf11bebcd2bfb07f7fb3f2a901054f4f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/7b"
     },
     {
         "type": "inline",
@@ -6163,12 +5446,6 @@
         "contents": "7ddafcb73a2e6f9bf126cdb16c87735c6e4dc015\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz\", \"integrity\": \"sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==\", \"time\": 0, \"size\": 4621, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7c9e3404de9212aefe3706d0ad202a663b6af36dcd7532e19428d480a26",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/02"
-    },
-    {
-        "type": "inline",
-        "contents": "7de3c1a12106c377ad3a3c870f561e185821c9e0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz\", \"integrity\": \"sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==\", \"time\": 0, \"size\": 19928, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4b4ba6bdc299187ed3c1f1b7f0606b0f0ee24d9da13d3fc7bb3798a6c915",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dc/27"
     },
     {
         "type": "inline",
@@ -6220,9 +5497,9 @@
     },
     {
         "type": "inline",
-        "contents": "808b6d6ea99cafa462539d5e1afa2857625df2bc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz\", \"integrity\": \"sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==\", \"time\": 0, \"size\": 3176, \"metadata\": {\"url\": \"https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "65a9170022f61107a83f47fe76708e4ccb920d67968ad87be7498563130c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/d1"
+        "contents": "80e8b3f69f3cab52ec07e463a9e7a1f369afe269\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.7.2.tgz\", \"integrity\": \"sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==\", \"time\": 0, \"size\": 28388, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aeeab81502bf6bc40dddaf47b6524fe0f109509e92c4bf4cd07fb00fdb05",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/f3"
     },
     {
         "type": "inline",
@@ -6235,12 +5512,6 @@
         "contents": "822595d2f9563ecb020d9c2f8d2523b2558e5926\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz\", \"integrity\": \"sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==\", \"time\": 0, \"size\": 4488, \"metadata\": {\"url\": \"https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "b5852a37a1c7a8587e01794c63ffc105ace222e8c117e0b7d8fceeb1b31a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/2b"
-    },
-    {
-        "type": "inline",
-        "contents": "82c496becc64a13a14bd05eeb81abf54066f16a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz\", \"integrity\": \"sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==\", \"time\": 0, \"size\": 7156, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3d3f79f40cfb8ca9a7800c5056f0101ca6819ad3c1fa01f6368577a53d7d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/22"
     },
     {
         "type": "inline",
@@ -6268,45 +5539,21 @@
     },
     {
         "type": "inline",
-        "contents": "84447d3bd7fde6f1a1c04f6f632696f3f8bcf3bc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/message/-/message-19.8.0.tgz\", \"integrity\": \"sha512-qs/5Vi9bYjf+ZV40bvdCyBn5DvbuelhR6qewLE8Bh476F7KnNyLfdM/ETJ4cp96WgeeHo6tesA2TMXS0sh5X4A==\", \"time\": 0, \"size\": 1600, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/message/-/message-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "091f284cc07705893f4f3e617a99d609ca012f06f1e2ba49657cf0f6bcab",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/f2"
-    },
-    {
-        "type": "inline",
-        "contents": "84fc3552878e45485dcbc70dc759e186bbabd1e5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz\", \"integrity\": \"sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==\", \"time\": 0, \"size\": 87023, \"metadata\": {\"url\": \"https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "eec56c824d65e35747a69f8e26e2467c1d63fa0c1b78fb00ac7ec1a6a67f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/5f"
-    },
-    {
-        "type": "inline",
         "contents": "853b28cb3e6e7a29e4deb8788010fd58ae704b37\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bl/-/bl-4.1.0.tgz\", \"integrity\": \"sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==\", \"time\": 0, \"size\": 14646, \"metadata\": {\"url\": \"https://registry.npmjs.org/bl/-/bl-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "24edb703ff3340274a7e3460aa90fb59d74803781cc9f955e4bc3acaa441",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/16"
     },
     {
         "type": "inline",
-        "contents": "85795dea1ecf7c402ce8472ecdc63256cebb23d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz\", \"integrity\": \"sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==\", \"time\": 0, \"size\": 139293, \"metadata\": {\"url\": \"https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0acdca37b8cc7145aae47941a4acde6fc2dd876377875417fbd0e59dba97",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/bf"
+        "contents": "8567afe08d1f4ca7ebfefec2174804ac5afa1f9e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz\", \"integrity\": \"sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==\", \"time\": 0, \"size\": 14174, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d8493c8b5ce7f54eeb5bb550f104a490da3b278f36fb6990fa5d9eb2480f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/2f"
     },
     {
         "type": "inline",
         "contents": "8666d22189f104ccc5ef690862922914e4966b58\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz\", \"integrity\": \"sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==\", \"time\": 0, \"size\": 2003, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9c712a5e8a00354e98f9eee025a14a8f8053ed29c4ade503136800b6c9ad",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/83"
-    },
-    {
-        "type": "inline",
-        "contents": "86ab3153dd66b3ecccfa524ed35885d02849ccf3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.0.tgz\", \"integrity\": \"sha512-CLanRQwuG2LPfFVvrkTrBR/L/DMy3+ETsgBqW1OvRxmzp/bbVJW0Xw23LnnExgYcsaFtos967lul1CsbsnJlzQ==\", \"time\": 0, \"size\": 5470, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "30d2bc9dbe9bd59ecb755febfb956f7ee6ba53af2338571bc55c11353a23",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/08"
-    },
-    {
-        "type": "inline",
-        "contents": "86cf0fadf344ff3570eecc447961f14b11e71a9a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/format/-/format-19.8.0.tgz\", \"integrity\": \"sha512-EOpA8IERpQstxwp/WGnDArA7S+wlZDeTeKi98WMOvaDLKbjptuHWdOYYr790iO7kTCif/z971PKPI2PkWMfOxg==\", \"time\": 0, \"size\": 3707, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/format/-/format-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "840345c922eebd461c8aa541b6fb145c9a11df920d9aa0ad296431eaf234",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/f3"
     },
     {
         "type": "inline",
@@ -6322,18 +5569,6 @@
     },
     {
         "type": "inline",
-        "contents": "875ee9631c144eb51a768f7fc8b3a93b87864281\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz\", \"integrity\": \"sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==\", \"time\": 0, \"size\": 462338, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "34709608681597c4d3ace855b27bd2e4bc1e69e92dd929257e0ab05d5f29",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/1d"
-    },
-    {
-        "type": "inline",
-        "contents": "87a4a7985d99182254f2259d6de8bebbcf0d6847\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz\", \"integrity\": \"sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==\", \"time\": 0, \"size\": 2021, \"metadata\": {\"url\": \"https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "43bc4bbdabf8ae0454ee7075000f4ba27acf124106cdb71a445723bbc8c9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/5c"
-    },
-    {
-        "type": "inline",
         "contents": "881081a1f5e97eb31b781a79e6ac179722ae439a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz\", \"integrity\": \"sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==\", \"time\": 0, \"size\": 3876, \"metadata\": {\"url\": \"https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "a5ed47b57569363a1a0a2c71442fd7066ee509a21252e92d9152a6fab7c8",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/8f"
@@ -6346,21 +5581,21 @@
     },
     {
         "type": "inline",
+        "contents": "8a55de641c24cef8f88f635bb57ca59734b8e4b4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz\", \"integrity\": \"sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==\", \"time\": 0, \"size\": 9765, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7fc4c4cf5e633db95b20c2ad74d1eda062f1a529834fc38af13a9307c0af",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/62"
+    },
+    {
+        "type": "inline",
         "contents": "8a956dc6e07c12a8ec899eaa6d3e550a400f8388\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz\", \"integrity\": \"sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==\", \"time\": 0, \"size\": 35047, \"metadata\": {\"url\": \"https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d30257844145b9960186e2f1012919bb37f622102497fe688776eb4e76a7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/c6"
     },
     {
         "type": "inline",
-        "contents": "8ac7e1df515296ed739a3385b3bee303e4076968\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.0.tgz\", \"integrity\": \"sha512-t/fCrLVu+Ru01h0DtlgHZXbHV2Y8gKocTR5elDOqIRUzQd0/6hpt2VIWOj9b3NDo7y4/gfxeR2zRtXq/qO6iUg==\", \"time\": 0, \"size\": 9756, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3528b9ad20407987e2f33666c4db86713888cbf19af9181355f5f8afcaec",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/47"
-    },
-    {
-        "type": "inline",
-        "contents": "8b50f98403d7ae80865c4e7c7e9771a30d7f143f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/socks/-/socks-2.8.3.tgz\", \"integrity\": \"sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==\", \"time\": 0, \"size\": 29872, \"metadata\": {\"url\": \"https://registry.npmjs.org/socks/-/socks-2.8.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c256e25ff3a4225d078adf72dc4e4eb6993a6c267c6d3972e1df007c44f8",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/72"
+        "contents": "8aaefa0816a25d57f1676ac956ef2e73ff2cbe87\t{\"key\": \"make-fetch-happen:request-cache:https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2\", \"integrity\": \"sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==\", \"time\": 0, \"size\": 564012, \"metadata\": {\"url\": \"https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e3821bd047ca393d43d18e4eba7bb6955c30774775224d93930b71cedec3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/6a"
     },
     {
         "type": "inline",
@@ -6382,21 +5617,15 @@
     },
     {
         "type": "inline",
-        "contents": "8d127c7f6038e76b2f6cb2d1f34cbac59fe49191\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz\", \"integrity\": \"sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==\", \"time\": 0, \"size\": 4831, \"metadata\": {\"url\": \"https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "469da539f6f336e366cb9edec72814077ffd341100a28dfb8cca1408d9af",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/73"
-    },
-    {
-        "type": "inline",
-        "contents": "8dd3a1e06b8d5b384fa2fb3e4c4a0ae284a01e1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz\", \"integrity\": \"sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==\", \"time\": 0, \"size\": 6792, \"metadata\": {\"url\": \"https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "61f663617acb9723f542888a3013dc12d0aa76452d33433d07e6d91f698f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/bb"
-    },
-    {
-        "type": "inline",
         "contents": "8e70c1566d2a126d311d3224316e888924d7606c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz\", \"integrity\": \"sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==\", \"time\": 0, \"size\": 3265, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "8a67a6a69c573e507dac8723fa56c0451c1ebb42aa08925c3bd37a8435c3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "8ec95c642fa54f468660cc5655f89f709d45cfcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lucide-static/-/lucide-static-0.511.0.tgz\", \"integrity\": \"sha512-/MWOjEyGZO84B16BeqbeleinbmeYxOBsbYDt/Yk6xGwMYwDm6dx43jKHMxGDqW9U84qWL13dNvVW0SMADhUSyg==\", \"time\": 0, \"size\": 5116544, \"metadata\": {\"url\": \"https://registry.npmjs.org/lucide-static/-/lucide-static-0.511.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "115f715122b04029a3b8fbd14b6d3718765bdb1215d7e3e6cdd46df9b209",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cc/6e"
     },
     {
         "type": "inline",
@@ -6409,12 +5638,6 @@
         "contents": "8f498db3c301f6f442fccce923dbf96a93ff776f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/plist/-/plist-3.1.0.tgz\", \"integrity\": \"sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==\", \"time\": 0, \"size\": 145420, \"metadata\": {\"url\": \"https://registry.npmjs.org/plist/-/plist-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2073ae784c88534a43261e1b45ea995702ed5b9c3b921f22c6957e6c9be9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/1e"
-    },
-    {
-        "type": "inline",
-        "contents": "8f6e4d4640bfe891df742e83399fa614c7db6d6d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.0.tgz\", \"integrity\": \"sha512-/jU9ettcntkBFmWUzzGgsClEi2ZFiikMX5eEQsmxIAWMOn4H3D4rvHssstmAHGVvrYnaMqdWWWg0b5M6IN/MTQ==\", \"time\": 0, \"size\": 446085, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "00928a9065585b7d44ec0ff07fdf35acf4373895d16f449c56b0882c7936",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/38/ed"
     },
     {
         "type": "inline",
@@ -6436,24 +5659,6 @@
     },
     {
         "type": "inline",
-        "contents": "9011b63074a9bc6134015360e69f809935afe331\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz\", \"integrity\": \"sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==\", \"time\": 0, \"size\": 1381, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "69ca72bc33373ca25324f36f58132b837615e22ce900fdf9831e12b0f750",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/22"
-    },
-    {
-        "type": "inline",
-        "contents": "90404abe45256dba309299596768b04f1cbcfb66\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz\", \"integrity\": \"sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==\", \"time\": 0, \"size\": 4851, \"metadata\": {\"url\": \"https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "11b20a49a4ff5826a73da604ca33e808545f5943f2133940c546fa4b1609",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/c3"
-    },
-    {
-        "type": "inline",
-        "contents": "907f76ea1cf8571a9ee47a9d1b316541671763e7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.0.tgz\", \"integrity\": \"sha512-3CKLUw41Cur8VMjh16y8LcsOaKbmQjAKCWlXx6B0vOUREplp6em9uIVhI8Cv934qiwkbi2+uv+mVZPnXJi1o9A==\", \"time\": 0, \"size\": 1621, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "74bbaa02d3a036caa04481a4cd41873feb3388a052e7f1ab8b5a9b6b1d5e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/8c"
-    },
-    {
-        "type": "inline",
         "contents": "90909794f2517bb2344a7bea719a9bbc419716d5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz\", \"integrity\": \"sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==\", \"time\": 0, \"size\": 4291, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "451566c35e0ffb68aab8ac1c209a6e76193021886ab3d2a020c20550886f",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/f2"
@@ -6472,12 +5677,6 @@
     },
     {
         "type": "inline",
-        "contents": "910778abe231b93acee7389fa488a53fec82cd8b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz\", \"integrity\": \"sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==\", \"time\": 0, \"size\": 15663, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1b3861be2e8f34413235c851bfd4ac085fd10dfa6d4ea610339de102f728",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/0e"
-    },
-    {
-        "type": "inline",
         "contents": "9126afeaddd66043090e27254115e0983fdfddc4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz\", \"integrity\": \"sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==\", \"time\": 0, \"size\": 4109, \"metadata\": {\"url\": \"https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "40755fd116126afd216c71b0e32d65209a5aa5258585607fca59e411384a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/48"
@@ -6490,21 +5689,15 @@
     },
     {
         "type": "inline",
-        "contents": "91938dae91e068c01e15f727096f5c3231f8d5e0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.0.tgz\", \"integrity\": \"sha512-9I2kKJwcAPwMoAj38hwqFXG0CzS2Kj+SAByPUQ0SlHTfb7VUhYVmo7G2w2tBrqmOf7PFd6MpZ/a1GQJo8na8kw==\", \"time\": 0, \"size\": 4686, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6d7b2fd062d91f738bdbc8dc17ab7aca7bc56df220541e64ea39fd84841b",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/04/74"
-    },
-    {
-        "type": "inline",
         "contents": "91cf859a57821d613590397910a610fa21e3daec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"integrity\": \"sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==\", \"time\": 0, \"size\": 6255, \"metadata\": {\"url\": \"https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e41f2c2713684e6e809753f5b2a642d98d5d19a1c17c03d0788531cebf88",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/7f"
     },
     {
         "type": "inline",
-        "contents": "9211b9c18d0919b0e85b3f8297f1bead5d24d2d7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.0.tgz\", \"integrity\": \"sha512-fthTTsi8CxaBXMaBAD7ST2uylwvsnYxh2PfaScwpMhos6KlSFajXQPcM4ogNE1q2s3Lbz9GCGqeIHC+C6OZnKg==\", \"time\": 0, \"size\": 1823, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "17fec821379a3dc72c4682bad08345fa81a868a1f4ceb7da2837c7c3b9f7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/60"
+        "contents": "9247d589d7f5bac1bc12f3b1c0d1111da56b4866\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz\", \"integrity\": \"sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==\", \"time\": 0, \"size\": 9859, \"metadata\": {\"url\": \"https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8b6a189885978398c48faf037da98ce10aa15508a1e736d7c7807e44e5f8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/35"
     },
     {
         "type": "inline",
@@ -6520,12 +5713,6 @@
     },
     {
         "type": "inline",
-        "contents": "930387d79476e1d64618e708bbc3a4dbe32114ad\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz\", \"integrity\": \"sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==\", \"time\": 0, \"size\": 3566, \"metadata\": {\"url\": \"https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8a41fc808dc3a75f728fad90921316b23f9325e5b104e74921762846f141",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/31"
-    },
-    {
-        "type": "inline",
         "contents": "93a155478d5243faeda776a11ebc832145ffee14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz\", \"integrity\": \"sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==\", \"time\": 0, \"size\": 4429, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ea55e4e584609a1f0ba14a730391c0b04141931864f08f4172886bec44f9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/7c"
@@ -6538,12 +5725,6 @@
     },
     {
         "type": "inline",
-        "contents": "9471ff40aac527c1645fc548a36de3d6b6f8a940\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz\", \"integrity\": \"sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==\", \"time\": 0, \"size\": 2524, \"metadata\": {\"url\": \"https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f63f8949d6f7b077129134f7ef4f10c7cb6dc5c8a34e531d4277624c273f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/93"
-    },
-    {
-        "type": "inline",
         "contents": "94ab05a57a80abe3da014e8fa0d0ea2221032751\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz\", \"integrity\": \"sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==\", \"time\": 0, \"size\": 17544, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "cbe69fec139759199ea70f787a7ac72777aef164153140226f7608da029c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/0f"
@@ -6553,12 +5734,6 @@
         "contents": "94b8d6a4c5f1545ef6e579d9f7fde82cc95af232\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"integrity\": \"sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==\", \"time\": 0, \"size\": 3756, \"metadata\": {\"url\": \"https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7afbc9eb60823c417e5dd1dd2f56b61e1b85cdd840120ff5644e6b03358",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/76"
-    },
-    {
-        "type": "inline",
-        "contents": "94d364f29b64cdf403b5b6ab287958c5cbfcd568\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz\", \"integrity\": \"sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==\", \"time\": 0, \"size\": 11266, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3b39289cebf40a8594d69713501d2f3f55dd9f6593f918d4d98e58bf776c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/80/4c"
     },
     {
         "type": "inline",
@@ -6580,21 +5755,9 @@
     },
     {
         "type": "inline",
-        "contents": "96afba3ac4af8fec77e683035de4d25943c49d62\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz\", \"integrity\": \"sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==\", \"time\": 0, \"size\": 7234, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "37c365cea78d40d3cd2a565f9c1bd20093d3650e446c6d7e54e6f282752c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/47"
-    },
-    {
-        "type": "inline",
         "contents": "97507166b50eb02a4fade9f4b87a79d6e18cc760\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz\", \"integrity\": \"sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==\", \"time\": 0, \"size\": 3634, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "117abea0e603ce799f25b072c29263ddba28676e10c4519e0964ef5b1fd4",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/d6"
-    },
-    {
-        "type": "inline",
-        "contents": "98c52b75d76cb07c8e99ecf38345d4a567f47a1e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz\", \"integrity\": \"sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==\", \"time\": 0, \"size\": 13281, \"metadata\": {\"url\": \"https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "55a7a11416f530733c4306be76bd0c19a89675981f79c119daa57ed2a7c1",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/bc"
     },
     {
         "type": "inline",
@@ -6622,21 +5785,9 @@
     },
     {
         "type": "inline",
-        "contents": "9a45aca729b8a23c82e0350060f1b4b1fddfb9fa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz\", \"integrity\": \"sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==\", \"time\": 0, \"size\": 4826, \"metadata\": {\"url\": \"https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "20e0adbd48da3892b6a09cd3146d3e957701719c545417aedbfff5528ac6",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/9d"
-    },
-    {
-        "type": "inline",
         "contents": "9a57ac345b0c48d88ae3659210d4f7866a4718c8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz\", \"integrity\": \"sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==\", \"time\": 0, \"size\": 20107, \"metadata\": {\"url\": \"https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "4a6a6af7def76a12350c0463d5b4f66033c904138d995826325878dd9440",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/51"
-    },
-    {
-        "type": "inline",
-        "contents": "9ac53dc5a153b8623cb82adac159da83c46ad289\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron/-/electron-36.2.0.tgz\", \"integrity\": \"sha512-5yldoRjBKxPQfI0QMX+qq750o3Nl8N1SZnJqOPMq0gZ6rIJ+7y4ZLp808GrFwjfTm05TYgq3GSD8FGuKQZqwEw==\", \"time\": 0, \"size\": 176466, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron/-/electron-36.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "001fdc92737a01690195fd7ff4fa312ac3ffe6733ea46fc3b6fb012cdc30",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0e/87"
     },
     {
         "type": "inline",
@@ -6646,21 +5797,33 @@
     },
     {
         "type": "inline",
-        "contents": "9b7c20c325820550edd1f929ad422f5cd227d017\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz\", \"integrity\": \"sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==\", \"time\": 0, \"size\": 2013, \"metadata\": {\"url\": \"https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4668fc5547bef87618e39882539fb8ca808e798939f2b4b8bdf5c11b82d2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f7/9c"
+        "contents": "9b7921fbbab985e4c4285dd651cce693e9e10dde\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz\", \"integrity\": \"sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==\", \"time\": 0, \"size\": 6655, \"metadata\": {\"url\": \"https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2451561f054e0e7e27d5df87c6fa6f2ba6a68cc3a01b777b5157f8d18497",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/5b"
     },
     {
         "type": "inline",
-        "contents": "9ba54d83e9e37d913a251ac14ed182ec0238ac11\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.0.tgz\", \"integrity\": \"sha512-t2vouuYQKEKSLtJaa5bB4jHeha2HJczQ6E5IXPDPgIty9EqcJxpr1QHQ86YyIPwDwxvUmLfP2YADQ5ZY4qddZg==\", \"time\": 0, \"size\": 18801, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "75a378a55a6e0b517973b2a0457d28ae37a829cf49e5fe2bd682676e8832",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/84"
+        "contents": "9b857b06d7ea2b65eb83d5ee1ed9b44ab62497d6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz\", \"integrity\": \"sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==\", \"time\": 0, \"size\": 41008, \"metadata\": {\"url\": \"https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "10c69bfe305e04c0f7158f76aee200fc40ac4e683d30e667b9c799a005bb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/b8"
     },
     {
         "type": "inline",
         "contents": "9be63e4c3fef0824ca87780f26d17957d0606418\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz\", \"integrity\": \"sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==\", \"time\": 0, \"size\": 9972, \"metadata\": {\"url\": \"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5d7b3f4c369d1d62065d5ca8f8572d2231a581ff043c996b2f5838c201ab",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/0e"
+    },
+    {
+        "type": "inline",
+        "contents": "9c29870e49d1e12d0738c8d1e55aa3e51ee1ae75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz\", \"integrity\": \"sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==\", \"time\": 0, \"size\": 4948, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "505bfe2b3e015a5bd1c170d1e7d016ec3dad010180d4c209ee18f1296909",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/ab"
+    },
+    {
+        "type": "inline",
+        "contents": "9c56e41659db1f27c9b0694590d987ac79515b02\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz\", \"integrity\": \"sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==\", \"time\": 0, \"size\": 15072, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e80352f8cfbb5fb59441accc9d9d984071059cc2d356c931ac0cb57866b0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/18"
     },
     {
         "type": "inline",
@@ -6682,12 +5845,6 @@
     },
     {
         "type": "inline",
-        "contents": "9e8eeacfc05ab4e807c97a39d94ed2a03cbeb276\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.6.tgz\", \"integrity\": \"sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==\", \"time\": 0, \"size\": 6635, \"metadata\": {\"url\": \"https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "73a12e8fbeb0c64818332546e4430fc1d776033ed7479c67cc9e4a39d2fb",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/83"
-    },
-    {
-        "type": "inline",
         "contents": "9efd18a561eea788bc847946f2966a225ae44dde\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz\", \"integrity\": \"sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==\", \"time\": 0, \"size\": 2783, \"metadata\": {\"url\": \"https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "94eb7a5af2f86dfcab6f8eebcc327f7a014c17456460d210967e2466a7d5",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/3c"
@@ -6700,9 +5857,9 @@
     },
     {
         "type": "inline",
-        "contents": "a0a5f6b7a2cfc76574db8029dadfccf327e08d9f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz\", \"integrity\": \"sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==\", \"time\": 0, \"size\": 5659, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0b6493f625a039ca4cb935e7526c5a564658f0781f039bc1e79ea8aa7a81",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/e7"
+        "contents": "a03df5cba49c7be6cac365853216619c1b8c83a0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/asar/-/asar-3.2.18.tgz\", \"integrity\": \"sha512-2XyvMe3N3Nrs8cV39IKELRHTYUWFKrmqqSY1U+GMlc0jvqjIVnoxhNd2H4JolWQncbJi1DCvb5TNxZuI2fEjWg==\", \"time\": 0, \"size\": 23482, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/asar/-/asar-3.2.18.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8ae9673e3f54be17d3c6f16e73accb18f5652ebc6b65723757d95ad4eea8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/04/5a"
     },
     {
         "type": "inline",
@@ -6715,12 +5872,6 @@
         "contents": "a0be89300eb8ed18b2befa067c479eba68163fb9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"integrity\": \"sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==\", \"time\": 0, \"size\": 2206, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7d95a8e3571758f8b5d095a21909a8f6cdfe7fd2349f7f72b2801eef079",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/d5"
-    },
-    {
-        "type": "inline",
-        "contents": "a0cd51686b818e3a2a342bb5bcfdf26662013794\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.0.tgz\", \"integrity\": \"sha512-+r5ZvD/0hQC3w5VOHJhGcCooiAVdynFlCe2d6I9dU+PvXdV3O+fU4vipVg+6hyLbQUuCH82mz3HnT/cBQTYYuA==\", \"time\": 0, \"size\": 4169, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "043b27afedd3753147a08d6d563b6093374b07bcc1b49f35995d606cdfe7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/5b"
     },
     {
         "type": "inline",
@@ -6754,15 +5905,15 @@
     },
     {
         "type": "inline",
-        "contents": "a2a6c3cb423fcec73db84de16e1624cb944cbbd9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime/-/mime-2.6.0.tgz\", \"integrity\": \"sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==\", \"time\": 0, \"size\": 18724, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime/-/mime-2.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2a0f2a6cea25e2b56b9059fe234a67034533d0170fb8c63247f93c2c37c2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/b2"
+        "contents": "a2a4da370aad42440010ad4725cc7006ecd41697\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz\", \"integrity\": \"sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==\", \"time\": 0, \"size\": 7201, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b0ba88bd619f29331042dd57d30d7e46d3c83f287987ea81410c9e3c2685",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/5d"
     },
     {
         "type": "inline",
-        "contents": "a2c6b13ca421d20668e3669d1845b0d1d92f12d6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz\", \"integrity\": \"sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==\", \"time\": 0, \"size\": 25747, \"metadata\": {\"url\": \"https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "5cb3f47ba8a17b62a575c388705c516448f9426b5f1e0bbbbe6f21f223d8",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/3f"
+        "contents": "a2a6c3cb423fcec73db84de16e1624cb944cbbd9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime/-/mime-2.6.0.tgz\", \"integrity\": \"sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==\", \"time\": 0, \"size\": 18724, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime/-/mime-2.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2a0f2a6cea25e2b56b9059fe234a67034533d0170fb8c63247f93c2c37c2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/b2"
     },
     {
         "type": "inline",
@@ -6778,21 +5929,15 @@
     },
     {
         "type": "inline",
+        "contents": "a2f3e9c64be21344803609f4e669ac7073621a1b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz\", \"integrity\": \"sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==\", \"time\": 0, \"size\": 9141554, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a7d97b9db8ab7a9936cede6325ef66063a510e16dc2e8bca79217ec8fe24",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/d5"
+    },
+    {
+        "type": "inline",
         "contents": "a389d3567858196e22be63c4bc7e9dfd47375183\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz\", \"integrity\": \"sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==\", \"time\": 0, \"size\": 14287, \"metadata\": {\"url\": \"https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f3d991647a77c6d90d2646904dc777dfcf6724822b5181965f940aa75ae7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/66/ac"
-    },
-    {
-        "type": "inline",
-        "contents": "a3f5ffc37f36f59fe173d1b5193aabaef2b7f935\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz\", \"integrity\": \"sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==\", \"time\": 0, \"size\": 29535, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e219d92944a2cd4993eb061933ef72c7eae1646500447becd9218e7139b9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/ab"
-    },
-    {
-        "type": "inline",
-        "contents": "a442c08d71413cd303dd1505d8b4049fc23343b4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz\", \"integrity\": \"sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==\", \"time\": 0, \"size\": 8900, \"metadata\": {\"url\": \"https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "543f9daca098c8c172c35b511a63fef7ab88b3e62620f431e4a59b96b3a2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/bf"
     },
     {
         "type": "inline",
@@ -6802,9 +5947,9 @@
     },
     {
         "type": "inline",
-        "contents": "a4c5d8c44d8988db5ac6ff7bdb5e3dc4ec124da9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz\", \"integrity\": \"sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==\", \"time\": 0, \"size\": 8220, \"metadata\": {\"url\": \"https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e542371e1aa84f2a351de966d3a9e6c5969ed89e41be1efcb3f58749cb8e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/be"
+        "contents": "a4b11140e51f133d11710322e36902eda06f64f8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz\", \"integrity\": \"sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==\", \"time\": 0, \"size\": 18801, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b138d46ab13292668c2413ba84f1ae84e394fa8d54a0bfc1f4a22738d361",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/f4"
     },
     {
         "type": "inline",
@@ -6814,15 +5959,15 @@
     },
     {
         "type": "inline",
-        "contents": "a4ee88f0d35669a5fbc15bc2d7c9227675212da1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz\", \"integrity\": \"sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==\", \"time\": 0, \"size\": 9822, \"metadata\": {\"url\": \"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4c69aba00431d506e9b53306eba6929ed6581502d7e8c77cb340635745a1",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1d/66"
-    },
-    {
-        "type": "inline",
         "contents": "a566771bd4586bf6b33abd57994a88d5c6a9331e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz\", \"integrity\": \"sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==\", \"time\": 0, \"size\": 15731, \"metadata\": {\"url\": \"https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ed9ecd577f0f5a15e1fd2bf415aee4807b1d8123d7ecd21743ad9afc346a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/38/66"
+    },
+    {
+        "type": "inline",
+        "contents": "a594df06e22af03ff1c6531b6a46dbc61fc0e72c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz\", \"integrity\": \"sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==\", \"time\": 0, \"size\": 6465, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ae718527d2b9bf7fa981d80037d5b2f7b34f0e34a76fdd3bc9b604b90077",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/f8"
     },
     {
         "type": "inline",
@@ -6844,12 +5989,6 @@
     },
     {
         "type": "inline",
-        "contents": "a61d00e29c6c65b253fb7f81d0b0567e0c89ce64\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz\", \"integrity\": \"sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==\", \"time\": 0, \"size\": 10107, \"metadata\": {\"url\": \"https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "cd6e2fb674dfeb362f52203428d3b6a209c607f96540bfd2880c73bdb032",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/1d"
-    },
-    {
-        "type": "inline",
         "contents": "a76b489dd427df71bc1d19f51dcb4687a354034b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/clone/-/clone-1.0.4.tgz\", \"integrity\": \"sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==\", \"time\": 0, \"size\": 4457, \"metadata\": {\"url\": \"https://registry.npmjs.org/clone/-/clone-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3f74a0ad77407b4c36348f6d53066e96e95a96acc2c0f150d57302873d68",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b2/00"
@@ -6859,12 +5998,6 @@
         "contents": "aa28ffd220acadd35f1a838551fd3de7c695dc0a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz\", \"integrity\": \"sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==\", \"time\": 0, \"size\": 8109, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "17d5aa3783c612239557f251b2be4fdcb43aec68db7405d1d6b7a9377c5d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/8d"
-    },
-    {
-        "type": "inline",
-        "contents": "aacce83433117bac21bbdc6459e5e0ef0bfea097\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz\", \"integrity\": \"sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==\", \"time\": 0, \"size\": 15268, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2995f4ef59769083df468069164c4fdbab939b7529cbe958e973b70053c5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/57"
     },
     {
         "type": "inline",
@@ -6880,21 +6013,9 @@
     },
     {
         "type": "inline",
-        "contents": "ab24dffabc846ab30322005386108def8986a10e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz\", \"integrity\": \"sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==\", \"time\": 0, \"size\": 4143, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ccfe251968ddfa436b59d92fcff67e2dda7da3d8499661a7b3a212c5fbb9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/e0"
-    },
-    {
-        "type": "inline",
         "contents": "abf5d5edf6646570fe285ecd9290e488941aecb6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz\", \"integrity\": \"sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==\", \"time\": 0, \"size\": 3944, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "22843aa980009e841925b84620bf13dc315af228240bf972425124b800f5",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/32"
-    },
-    {
-        "type": "inline",
-        "contents": "ac66317948de2c3b6a24831065e3dc83880d8191\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz\", \"integrity\": \"sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==\", \"time\": 0, \"size\": 4600, \"metadata\": {\"url\": \"https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0fe70178cc20564856430b048bf0c78ab50e448d4897bc74debbaf2c1934",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/93"
     },
     {
         "type": "inline",
@@ -6940,12 +6061,6 @@
     },
     {
         "type": "inline",
-        "contents": "adc3f45abefbce47600ce7d0aae61383ed5aa414\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz\", \"integrity\": \"sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==\", \"time\": 0, \"size\": 4914, \"metadata\": {\"url\": \"https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e7aae0a80af27357ea981c02672d0fda98d97677f0ddb661d94547f15756",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/0f"
-    },
-    {
-        "type": "inline",
         "contents": "ae24fe580c7218ee63fcc86476862a5db5aa98e8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz\", \"integrity\": \"sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==\", \"time\": 0, \"size\": 65652, \"metadata\": {\"url\": \"https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "0344c53990466cd8be074a97a885eb0d582fa6f17493f9c2d4b391dda9b6",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/65"
@@ -6964,33 +6079,9 @@
     },
     {
         "type": "inline",
-        "contents": "af70ed5262fa02c439ec43a3b6335b69c2364d19\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz\", \"integrity\": \"sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==\", \"time\": 0, \"size\": 23622, \"metadata\": {\"url\": \"https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c13247f75e29e3455187cf9e68afada3c5e3a8df7a0eb739acd1ddb364da",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/25"
-    },
-    {
-        "type": "inline",
         "contents": "af94b9a500ee4631018c9a104b5d108b60d4aea7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz\", \"integrity\": \"sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==\", \"time\": 0, \"size\": 4255, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2ac6234e08578459cc70534addafba44ecd5267c7510db659945c34b184d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/ea"
-    },
-    {
-        "type": "inline",
-        "contents": "afb013de6a78799aaf358f51ff3ec6c678e676c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz\", \"integrity\": \"sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==\", \"time\": 0, \"size\": 1656, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8d2a4008152fdd042618e790009959fdd975e6198e9d1792da7bc117e5a7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/98"
-    },
-    {
-        "type": "inline",
-        "contents": "b01f87655a9af016c48fbf5df305fe5d40c63501\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz\", \"integrity\": \"sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==\", \"time\": 0, \"size\": 2848, \"metadata\": {\"url\": \"https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1a61cda7de4352f7e0bed89ca396c491eabaab671d80044972456eb50ba5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/f3"
-    },
-    {
-        "type": "inline",
-        "contents": "b0238bc669c6b4203032a293c68a6ded6285aa45\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz\", \"integrity\": \"sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==\", \"time\": 0, \"size\": 2212, \"metadata\": {\"url\": \"https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b4eaa023d06f838c97818e3714054b5b460d1e8679160f6dfe031012cb73",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/51"
     },
     {
         "type": "inline",
@@ -7066,33 +6157,15 @@
     },
     {
         "type": "inline",
-        "contents": "b3d32b64291a4d60c5e4ef025c6e6a195795a655\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz\", \"integrity\": \"sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==\", \"time\": 0, \"size\": 44766, \"metadata\": {\"url\": \"https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4c6fd5612ed923286dbb10bcdf5f09461eb7eed9e276d162edd52a100f61",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/f2"
-    },
-    {
-        "type": "inline",
         "contents": "b3f8bcac4dcb55d72f6adf23ed626b639e593dc4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pend/-/pend-1.2.0.tgz\", \"integrity\": \"sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==\", \"time\": 0, \"size\": 2308, \"metadata\": {\"url\": \"https://registry.npmjs.org/pend/-/pend-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ef10506d9af10cc8969d51b7bfb3919d10ea54d75da0800a91dd20720306",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/76"
     },
     {
         "type": "inline",
-        "contents": "b3f9467b542cc579cfc42c4999f6829577ff8e01\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz\", \"integrity\": \"sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==\", \"time\": 0, \"size\": 3603, \"metadata\": {\"url\": \"https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d054517822a51ddd85fa4b08ae1bd6fbdf9bc852463e74719884a3a9dae6",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/7f"
-    },
-    {
-        "type": "inline",
-        "contents": "b4430074ff51435673aa886e81831f0e33f88868\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz\", \"integrity\": \"sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==\", \"time\": 0, \"size\": 10320, \"metadata\": {\"url\": \"https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ccd53cf0f8b79f023488d5ab8785edc5ac7ff1e091b3a680b98d248101f5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/52"
-    },
-    {
-        "type": "inline",
-        "contents": "b50054893412dd9c592722bd5de19ed4f24dd04a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/execa/-/execa-8.0.1.tgz\", \"integrity\": \"sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==\", \"time\": 0, \"size\": 19566, \"metadata\": {\"url\": \"https://registry.npmjs.org/execa/-/execa-8.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c828ea59619094de4f40fdab64b5639ad3c34dc9f30f1997ac3694d57ade",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/7a"
+        "contents": "b44a0b97a7de4c77ed39a4e6fcce3c07ec93ca91\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz\", \"integrity\": \"sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==\", \"time\": 0, \"size\": 4946, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "239da41663cdd862cf5bff56c2591726c7b510b7e14be9cde8b515cd20c3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/62/74"
     },
     {
         "type": "inline",
@@ -7120,12 +6193,6 @@
     },
     {
         "type": "inline",
-        "contents": "b7e3af32a41637823674622bba54f455fc41c390\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz\", \"integrity\": \"sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==\", \"time\": 0, \"size\": 9233, \"metadata\": {\"url\": \"https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "758cb7487272e53067e86ffad247365211a40049d2f0fa7510d9be37f0f9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d4/bd"
-    },
-    {
-        "type": "inline",
         "contents": "b80b8ae25a2a10c0c5b6691530dbf72e2c5f7a6b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"integrity\": \"sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==\", \"time\": 0, \"size\": 5849, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c2ea22c4bf9c5ddcd0333850e543442de3364478847c7ebc382b1ff3a70d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/8b/ee"
@@ -7150,15 +6217,15 @@
     },
     {
         "type": "inline",
-        "contents": "b909e3837e814a24202d246fb4f0c7d555cd8138\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz\", \"integrity\": \"sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==\", \"time\": 0, \"size\": 40074, \"metadata\": {\"url\": \"https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "5d1e3f150d9f3d80f6b05f9bbe1721fab97f0cff2d87fa759d45beb9ea86",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/4b"
-    },
-    {
-        "type": "inline",
         "contents": "b90f8e54c94da02989f18777eee73af9278fb00e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz\", \"integrity\": \"sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==\", \"time\": 0, \"size\": 2756, \"metadata\": {\"url\": \"https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "483598f2f71313734ffeeba67883f6e17e9a0f7e14abb904bac587630683",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/b4"
+    },
+    {
+        "type": "inline",
+        "contents": "b968cf4dbbe4aa8f97082dbf4a65bea2f46085f0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz\", \"integrity\": \"sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==\", \"time\": 0, \"size\": 56875, \"metadata\": {\"url\": \"https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "901193f02f04ce6b3d40b8714038e33af7e8c4c0ac5bbf76d77da743b080",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/e9"
     },
     {
         "type": "inline",
@@ -7168,9 +6235,9 @@
     },
     {
         "type": "inline",
-        "contents": "bb2ef2fe3497bf3b44af443fd6ed74d167b72bf0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz\", \"integrity\": \"sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==\", \"time\": 0, \"size\": 5495, \"metadata\": {\"url\": \"https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "46483cdb2b8e7e36f619bdac8eb94950e912856ea1423ee38a6164941514",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/24"
+        "contents": "bb33af90ec7766f7876d510b2c8915e8037df72a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz\", \"integrity\": \"sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==\", \"time\": 0, \"size\": 1957, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b2744c9b7451d9d711ce53d5887c8e2e77f841cb8be43df29cc1a7efcfc3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ff/5e"
     },
     {
         "type": "inline",
@@ -7204,21 +6271,9 @@
     },
     {
         "type": "inline",
-        "contents": "bcf9c3334b7076b8bc84194cca450ffb67ade3c5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz\", \"integrity\": \"sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==\", \"time\": 0, \"size\": 6162, \"metadata\": {\"url\": \"https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1814921274cc7b53643ef3468204e5602cc807a87573121e18d7f4cda8d0",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/47"
-    },
-    {
-        "type": "inline",
         "contents": "bd2a610aa5f499723bbf0e1a3d74cd84fa94a7ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz\", \"integrity\": \"sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==\", \"time\": 0, \"size\": 2663, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "76c21652f2169a69eaaea1063b83090d4a616b9b952147bafbb6e4588813",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/6b"
-    },
-    {
-        "type": "inline",
-        "contents": "bd3826611ff7a9fa719139a1660e9bcb3fac1adb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.0.tgz\", \"integrity\": \"sha512-L2Jv9yUg/I+jF3zikOV0rdiHUul9X3a/oU5HIXhAJLE2+TXTnEBfqYP9G5yMw/Yb40SnR764g4fyDK6WR2xtpw==\", \"time\": 0, \"size\": 3072, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ccc325e7a7d88b492b9d7f0705c22288edd717dacca2fadfb83413536233",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/55/20"
     },
     {
         "type": "inline",
@@ -7258,21 +6313,9 @@
     },
     {
         "type": "inline",
-        "contents": "c19cb60f0336938327d0ffb91a8d73817f453e0c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz\", \"integrity\": \"sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==\", \"time\": 0, \"size\": 11514, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ab4b28332a4d7e414dbf68efddf3929487a244361f93af6887c4ed4e2b94",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/6f"
-    },
-    {
-        "type": "inline",
         "contents": "c1bc12d4660cf805ffd01ac09da9a8c5f77f7321\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz\", \"integrity\": \"sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==\", \"time\": 0, \"size\": 2150, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "bb26881bebb5d0c5a7079205d1537cb18d2d17ba6c21e93ee41e9a863322",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/cf"
-    },
-    {
-        "type": "inline",
-        "contents": "c255605298415fb25f5875839301d5a3284fc7e5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz\", \"integrity\": \"sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==\", \"time\": 0, \"size\": 13328, \"metadata\": {\"url\": \"https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "bafe8f6d972671ef079164b04453452bac39068e58c9f60997a487dda603",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/2d"
     },
     {
         "type": "inline",
@@ -7285,6 +6328,12 @@
         "contents": "c2dec06c1ccb2f618d50967b9ed8e22c5fb1cbfd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz\", \"integrity\": \"sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==\", \"time\": 0, \"size\": 18518, \"metadata\": {\"url\": \"https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "a43ed62c85ef934dfef67d44393a82fa1338d4ac74e2f138980482f44822",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a9/bc"
+    },
+    {
+        "type": "inline",
+        "contents": "c2e02390f2a1e8f289333701962bbd9bf87e9f87\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz\", \"integrity\": \"sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==\", \"time\": 0, \"size\": 2472, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "27044a2ad4976da4157e99342dd0414afb8b70e2d1bbf43fffc698925a68",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/69"
     },
     {
         "type": "inline",
@@ -7318,12 +6367,6 @@
     },
     {
         "type": "inline",
-        "contents": "c66a28d19cec3579b694b8adb4894f85ec834e60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz\", \"integrity\": \"sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==\", \"time\": 0, \"size\": 3658, \"metadata\": {\"url\": \"https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e9fc2a4b947bedffa8d6d84e3e24c9ce64f308cded0c0561fb0305521db1",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8c/61"
-    },
-    {
-        "type": "inline",
         "contents": "c724baa464622e99f67cd486cf902ab4070333cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz\", \"integrity\": \"sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==\", \"time\": 0, \"size\": 4474, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c68ba9a1320725050b57ca9c7fbc237e694f1f4a6cb94104f7e3e654f7f4",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/fb"
@@ -7336,15 +6379,21 @@
     },
     {
         "type": "inline",
-        "contents": "c7e7d373ee7ead828d5d5ad7c3bd45304dfbd040\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz\", \"integrity\": \"sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==\", \"time\": 0, \"size\": 2030462, \"metadata\": {\"url\": \"https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3f201b3f4225c2b42490d2ee84c8ef5eb6a736ea81efdce1a9bae5fea6d7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/6c"
+        "contents": "c787b30db7253b6f165bc507bacb61fbf609bc49\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.0.tgz\", \"integrity\": \"sha512-VW++CNSlZwMYP7MyXEbrKjpzEwhB5kDNbzGtiPEjwYysqyTCF+YbNJ210Dj3AjWsGSV4iEEwNkmJN9yGZmVvmw==\", \"time\": 0, \"size\": 37348, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cbf51129de1bfe08f99637fada41c18bbf0300296623ba680185ca564c31",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/38/e4"
     },
     {
         "type": "inline",
-        "contents": "c7f4f278c2fe948a163056bd26d68274c63e4f54\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz\", \"integrity\": \"sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==\", \"time\": 0, \"size\": 72509313, \"metadata\": {\"url\": \"https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "30b07c3a02a7f7c0ac7858c77face10b1c3bdc0696bc4f788e6699289af0",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/46"
+        "contents": "c7d8b5b2a40927c41e5fd3049d94c7bd1d0e3224\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz\", \"integrity\": \"sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==\", \"time\": 0, \"size\": 116425, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "536b047b98ce428bd5e0cd6f574e0d62d0761f6543b4e7d36c51a1d3162c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/fe"
+    },
+    {
+        "type": "inline",
+        "contents": "c7e7d373ee7ead828d5d5ad7c3bd45304dfbd040\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz\", \"integrity\": \"sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==\", \"time\": 0, \"size\": 2030462, \"metadata\": {\"url\": \"https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3f201b3f4225c2b42490d2ee84c8ef5eb6a736ea81efdce1a9bae5fea6d7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/6c"
     },
     {
         "type": "inline",
@@ -7360,12 +6409,6 @@
     },
     {
         "type": "inline",
-        "contents": "c8a961e4fc0e8b82a08fe7cdc237c2b69165197a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz\", \"integrity\": \"sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==\", \"time\": 0, \"size\": 40713, \"metadata\": {\"url\": \"https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8ffb9961b45de9272005e2abb62ea4bdd7d2537348352ab272a2787abd59",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/1f"
-    },
-    {
-        "type": "inline",
         "contents": "c8dc69aa53afdcd39b445f0c8cd5ac47dee550bf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz\", \"integrity\": \"sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==\", \"time\": 0, \"size\": 6664, \"metadata\": {\"url\": \"https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c147816be94e86ed9bbb4b9e20409e4791a8991fcfd41d7a44489dedd29b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/90"
@@ -7378,21 +6421,9 @@
     },
     {
         "type": "inline",
-        "contents": "c9a5de8e1390b6721a2ae0df36bdefe70974b522\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz\", \"integrity\": \"sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==\", \"time\": 0, \"size\": 9971, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6b56d18243538dc36f4e24754c33e9310af75e771e9e592592323e7894df",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/83/3f"
-    },
-    {
-        "type": "inline",
         "contents": "c9e3d6e08d73510bffcdcc6883ddeba6a0cd516c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz\", \"integrity\": \"sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==\", \"time\": 0, \"size\": 2068, \"metadata\": {\"url\": \"https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5296f26e207d1371c8f95bf082321237691bc5e5db64b66d0ffd6ffa99ab",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/d9"
-    },
-    {
-        "type": "inline",
-        "contents": "c9e8ec52164fa34d6a7643ad7276d540b13162e1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz\", \"integrity\": \"sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==\", \"time\": 0, \"size\": 7109, \"metadata\": {\"url\": \"https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3f5ec0212fa3d207877e44a748f930a68ac51a3fba93c5d9f41e959cc350",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/72"
     },
     {
         "type": "inline",
@@ -7408,21 +6439,9 @@
     },
     {
         "type": "inline",
-        "contents": "ca415f00d47e1839f18a906943f31f47fc8a468c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz\", \"integrity\": \"sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==\", \"time\": 0, \"size\": 11171, \"metadata\": {\"url\": \"https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "7720295b4507bb36a41b74b79c9c06c9fb8cbd884959831e67b44a9fa505",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/0d"
-    },
-    {
-        "type": "inline",
         "contents": "ca9b99858cbf069d08cc98632710bff5f8717041\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.2.0.tgz\", \"integrity\": \"sha512-avvo1xxkLbv2dgtabdewBbqcJfV0e0zCwFqkPMnHFGbJbBHorRFfMAHh1NG9ymmXn0jW95ibUVH03E1NYXD6Gw==\", \"time\": 0, \"size\": 8755, \"metadata\": {\"url\": \"https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "91a85b766e852264a9aa16130c32f4b1015148e70ea7a3f49d70cb630872",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/e5/f8"
-    },
-    {
-        "type": "inline",
-        "contents": "caf255b1b74bf8cd12813ce93cae99304449454a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.0.tgz\", \"integrity\": \"sha512-+/NZKyWKSf39FeNpqhfMebmaLa1P90i1Nrb1SrA7oSU5GNN/lksA4z6+ZTnsft01YfhRZSYMbgGsARXvkr/VLQ==\", \"time\": 0, \"size\": 4705, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f0cf88bd9905790d6a54a7cee793c1214a4070fe90a57919f2fdb788cc26",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f7/49"
     },
     {
         "type": "inline",
@@ -7486,6 +6505,12 @@
     },
     {
         "type": "inline",
+        "contents": "cef583ea94f94812055c117f8b09248dfd125631\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz\", \"integrity\": \"sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==\", \"time\": 0, \"size\": 10390, \"metadata\": {\"url\": \"https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9240e9aa00502890e446f3ca13eecb8db1d2919f2e384b6e06a55d304502",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/f1"
+    },
+    {
+        "type": "inline",
         "contents": "cf18bad9e243e05bc08340a0670e330f54cf0b03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz\", \"integrity\": \"sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==\", \"time\": 0, \"size\": 2190, \"metadata\": {\"url\": \"https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c03134d3b6216050d19cb8276cd28d5ae942c859d0bc3758b53face0594c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/bb"
@@ -7504,6 +6529,12 @@
     },
     {
         "type": "inline",
+        "contents": "d03222ba1f315011db57494923cf793cc158e7cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz\", \"integrity\": \"sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==\", \"time\": 0, \"size\": 6300, \"metadata\": {\"url\": \"https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "03c7e6b3525c2d06e57d93645ceef47a04f81ebeedbe4b673b020b353227",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/73"
+    },
+    {
+        "type": "inline",
         "contents": "d04bf98c4456aeda2a0b458ee15e7b791a21335e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz\", \"integrity\": \"sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==\", \"time\": 0, \"size\": 8913, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3823be4be0216c6b586c2eeec514837e4811d9f2cf65ab1e5bda679f7fdf",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/35"
@@ -7513,12 +6544,6 @@
         "contents": "d0515182a4d32ff4d970def41ccd9eaa6b433ce6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz\", \"integrity\": \"sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==\", \"time\": 0, \"size\": 6828, \"metadata\": {\"url\": \"https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e94403f1afd2fed5b3e826107e8cd76b0c1b10f404aa820f369ed9d7fe52",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/09"
-    },
-    {
-        "type": "inline",
-        "contents": "d083185c8d77383397cd90dd7809d3605fc47d14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz\", \"integrity\": \"sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==\", \"time\": 0, \"size\": 3864, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a18afeeacddb252d3fdb2fef4e229313a89ec7c149ae7cdf62a68fa85877",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/ab"
     },
     {
         "type": "inline",
@@ -7588,15 +6613,15 @@
     },
     {
         "type": "inline",
-        "contents": "d6ad3b7ca26d76c61c9404978252a97f08ef11e6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz\", \"integrity\": \"sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==\", \"time\": 0, \"size\": 2968, \"metadata\": {\"url\": \"https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0295a7f28814b7e11d7b4dc7640719c98649910fbb476c1f478c89f476b5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/db/f6"
-    },
-    {
-        "type": "inline",
         "contents": "d6fe2445a6eae6a00d31497db1a9f73dfc553ade\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz\", \"integrity\": \"sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==\", \"time\": 0, \"size\": 2813, \"metadata\": {\"url\": \"https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "297e6081f2050d08959be634218f7dc79469d7a8742e8eb0d087205d0e19",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "d70fd25c7fc7ca3f56f0509f26bb66a24bfaadfa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz\", \"integrity\": \"sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==\", \"time\": 0, \"size\": 12526, \"metadata\": {\"url\": \"https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f08d99d204d9b332593c9d82e283fd35df58564f1107993589c67c454baf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/6a"
     },
     {
         "type": "inline",
@@ -7621,12 +6646,6 @@
         "contents": "d879978b41161ee956b6ba11a3fd38f48ccaa15a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz\", \"integrity\": \"sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==\", \"time\": 0, \"size\": 4239, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6532bc014331c9b572482a4bd805bf54a7ff8b4ca179b1c811aff3dec690",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/ff"
-    },
-    {
-        "type": "inline",
-        "contents": "d8ce1c5d033819e1c3ddbdef7169cc743c3a1d60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz\", \"integrity\": \"sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==\", \"time\": 0, \"size\": 7750, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6e01e0a33342f552257e2351f2cd7d26148bd9d2c73fc3797a4c4ddb0e39",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/50"
     },
     {
         "type": "inline",
@@ -7678,12 +6697,6 @@
     },
     {
         "type": "inline",
-        "contents": "dd5c47078c0506f5302d49466a3015c35a1fda93\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz\", \"integrity\": \"sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==\", \"time\": 0, \"size\": 8653, \"metadata\": {\"url\": \"https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e09e3281a8e9ffd847df69563c2ab1fff00157bda2bb931671880e325f70",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/33"
-    },
-    {
-        "type": "inline",
         "contents": "dd71d391c9de9e8ac0b89e228a72e904bf34b9fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz\", \"integrity\": \"sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==\", \"time\": 0, \"size\": 26650, \"metadata\": {\"url\": \"https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3a65eccea4ca04855d7844772466a7bd372d2aafee069252572fec3cc2bb",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/a3"
@@ -7696,21 +6709,15 @@
     },
     {
         "type": "inline",
-        "contents": "de265d4d23e8dd55ab2501a431160056f8784f86\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz\", \"integrity\": \"sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==\", \"time\": 0, \"size\": 8572, \"metadata\": {\"url\": \"https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "5d88fab18bc5129c2e116940930310232e43dd6f62367ef737d7c26d6b92",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/7f"
-    },
-    {
-        "type": "inline",
-        "contents": "de896daa4c1c4d358fe0f4114ce2e5360df3512a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cors/-/cors-2.8.5.tgz\", \"integrity\": \"sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==\", \"time\": 0, \"size\": 6173, \"metadata\": {\"url\": \"https://registry.npmjs.org/cors/-/cors-2.8.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "036f9e32a04302b004a28601c97f1d82d8eb2561527e2a06d734658a6d57",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/44/c4"
-    },
-    {
-        "type": "inline",
         "contents": "dec4fa36f7c4ab7cb0d2f0d60af0fb0f07fb1666\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz\", \"integrity\": \"sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==\", \"time\": 0, \"size\": 2625, \"metadata\": {\"url\": \"https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c9aa1c46bf0c67511379e97bd07fca87532422f2506214f94db8861160d3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/5e"
+    },
+    {
+        "type": "inline",
+        "contents": "df494e0c7697c3599dc3823233bcc1679aaace81\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz\", \"integrity\": \"sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==\", \"time\": 0, \"size\": 8998, \"metadata\": {\"url\": \"https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4fb51f0d6958df4998537c738c83e14af659c6a2ac678defad66458c5358",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/0c"
     },
     {
         "type": "inline",
@@ -7723,30 +6730,6 @@
         "contents": "dfc095b983a77202312a4ce77cc7f9a7b0355b22\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"integrity\": \"sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==\", \"time\": 0, \"size\": 3210, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "0913a74f5e223a4fe6108493dd3b03c2d47259df459926160659513c9ad3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/f4"
-    },
-    {
-        "type": "inline",
-        "contents": "e046dcefc3f11c2bf9ae36427cb874f1360d2833\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.0.tgz\", \"integrity\": \"sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==\", \"time\": 0, \"size\": 4946, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "9d3070de8de334d480f199469ae03caf817d1ad91de96260aa20aa8e05b2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d8/ce"
-    },
-    {
-        "type": "inline",
-        "contents": "e12dabdc8ce6453680a85f6ef2ff24b567b59341\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz\", \"integrity\": \"sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==\", \"time\": 0, \"size\": 3260, \"metadata\": {\"url\": \"https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "897eb528b49f72edbf46d95c24a1e7aae7eb6624f45678a52940bfebc25c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1d/e8"
-    },
-    {
-        "type": "inline",
-        "contents": "e1652d4da224712793eb44d47f164d2a844d5105\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz\", \"integrity\": \"sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==\", \"time\": 0, \"size\": 111348, \"metadata\": {\"url\": \"https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b79df0bcb89f3d76e6a827ce413f31c5400f25e5e8047aa21a40724a7bbc",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/7b"
-    },
-    {
-        "type": "inline",
-        "contents": "e39a1a115aff049545109154d0d6cc87c9ca3ab8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz\", \"integrity\": \"sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==\", \"time\": 0, \"size\": 3914, \"metadata\": {\"url\": \"https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6b45375ef86aed02210a45c62fe4d8a67e7db5524b600c1c62cc471bf67d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/54"
     },
     {
         "type": "inline",
@@ -7771,12 +6754,6 @@
         "contents": "e3dcc64bc8de892e882ef15fc11a750b1e8e6ffb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz\", \"integrity\": \"sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==\", \"time\": 0, \"size\": 1927, \"metadata\": {\"url\": \"https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "279e8188ca0f6ffefda0f94dc97a8ff608b71872a5f99a2783484b081e46",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/31"
-    },
-    {
-        "type": "inline",
-        "contents": "e4b19a3a821000755c61732732333bda27584430\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz\", \"integrity\": \"sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==\", \"time\": 0, \"size\": 6266, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "622ddd7805e9d206d5e55907c4aab83d5859954a87e7d8cc39e9182c4f10",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/b3"
     },
     {
         "type": "inline",
@@ -7810,27 +6787,27 @@
     },
     {
         "type": "inline",
-        "contents": "e616d92213de1618fb0c357955eb9135f788167e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz\", \"integrity\": \"sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==\", \"time\": 0, \"size\": 6382, \"metadata\": {\"url\": \"https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "5912d88421e6b76e5e0365ae8015aac3093d6e53b5b60fdfa91116720417",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/e2"
-    },
-    {
-        "type": "inline",
         "contents": "e61da51e2306d7fb1d7d099c38776ed83a6bc89c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz\", \"integrity\": \"sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==\", \"time\": 0, \"size\": 1978, \"metadata\": {\"url\": \"https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "05527c602af6f41b07e26f44ccd354c04e9663fdb7b78252f2f869c3cf7f",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/93/ca"
     },
     {
         "type": "inline",
-        "contents": "e61fb3b627409a1e7ecf25d584aeb317580c7c07\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/depd/-/depd-2.0.0.tgz\", \"integrity\": \"sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==\", \"time\": 0, \"size\": 8374, \"metadata\": {\"url\": \"https://registry.npmjs.org/depd/-/depd-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8564823aa3255dcec81b524fd590e5f3349ee1ada7d35311efcf7dcc5018",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/cb"
+        "contents": "e6cee7b122e50e8d44f82a4b40629826a7dab312\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-publish/-/electron-publish-26.0.11.tgz\", \"integrity\": \"sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A==\", \"time\": 0, \"size\": 33574, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-publish/-/electron-publish-26.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "baf0f5314f710d16a3d4bcbb074e2f63de34ecf817c71ffd3e2b83b46b38",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/94/e8"
     },
     {
         "type": "inline",
-        "contents": "eb16598c80e946907ebe0fdffdb9123f2ad28b49\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz\", \"integrity\": \"sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==\", \"time\": 0, \"size\": 11670, \"metadata\": {\"url\": \"https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3105b066c2c6aa6572229d813ca25955229e067ee026bac572fae6db2e57",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/8c"
+        "contents": "e82e36c094f13fe4aa912c717142fab3e6c6ae2d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz\", \"integrity\": \"sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==\", \"time\": 0, \"size\": 446232, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e9c79901842c8dc64d4afd5fe0196da24c1cf31915df0d5e2e5b4a23f819",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/7d"
+    },
+    {
+        "type": "inline",
+        "contents": "e907c0e842454b436f48aa6285eeb5add8438988\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz\", \"integrity\": \"sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==\", \"time\": 0, \"size\": 1878, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "34b8f549d763f9583ffbafa18d2b62d1ce4c0aa482ae63a65de156b49543",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/df"
     },
     {
         "type": "inline",
@@ -7846,21 +6823,15 @@
     },
     {
         "type": "inline",
+        "contents": "ebbce10e511dd7438a080e1452fe03c14c299fb9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builder-util/-/builder-util-26.0.11.tgz\", \"integrity\": \"sha512-xNjXfsldUEe153h1DraD0XvDOpqGR0L5eKFkdReB7eFW5HqysDZFfly4rckda6y9dF39N3pkPlOblcfHKGw+uA==\", \"time\": 0, \"size\": 37396, \"metadata\": {\"url\": \"https://registry.npmjs.org/builder-util/-/builder-util-26.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "412729f30dcd551876ff9f03bd0ade4930629c398543f1fa32a77a1c1a9a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/da"
+    },
+    {
+        "type": "inline",
         "contents": "ec53d0c93d6df88003783aa99c0982908c82675e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz\", \"integrity\": \"sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==\", \"time\": 0, \"size\": 129318, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9419de5c3a14e7b5f4b06afb096559411695fb1b5de04803a76b8d1fcaea",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/43"
-    },
-    {
-        "type": "inline",
-        "contents": "ec99589483a84074c4a8909e93b19da14a5e647f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.0.tgz\", \"integrity\": \"sha512-Rphgoc/omYZisoNkcfaBRPQr4myZEHhLPx2/vTXNLjiCw4RgfPR1wEgUpJ9OOmDCiv5ZyIExhprNLhteqH4FuQ==\", \"time\": 0, \"size\": 1976, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ae5d7528e8c6fdf64f0518a7f49e13810eabb26ecf7360d86baca89982f0",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/b8"
-    },
-    {
-        "type": "inline",
-        "contents": "ecc9777a10db41e786d23c2bd6fe2684e0df061e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.0.tgz\", \"integrity\": \"sha512-UMq2kxdXCzinFFPsXc9o2ozIpYCCOiEC46MG3yEh5Vipq6BO27otTtEBZA1fQ66DulEUgE97ucQ/3YY66CPg0A==\", \"time\": 0, \"size\": 6300, \"metadata\": {\"url\": \"https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8d5078ee5e6ac9e7fdde3cddac77144d832a8b3f5cf96f98a2f9e68415d2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/1d"
     },
     {
         "type": "inline",
@@ -7873,6 +6844,12 @@
         "contents": "ee385bfdc404ea4be66484156b7442990af1de70\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz\", \"integrity\": \"sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==\", \"time\": 0, \"size\": 1600, \"metadata\": {\"url\": \"https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f57914191cef830eec2d4811049e92075aab602d013176512a03fb105dc3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/27"
+    },
+    {
+        "type": "inline",
+        "contents": "ee74a0bbba7904e68168e039b27b255427396b03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz\", \"integrity\": \"sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==\", \"time\": 0, \"size\": 5583, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9df6136179e75a89f9d3914f7535bf2a6318e5c002f7257fc49bc7b83ece",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/8e"
     },
     {
         "type": "inline",
@@ -7936,6 +6913,12 @@
     },
     {
         "type": "inline",
+        "contents": "f2addcbb45b8b0199130a9af5cb5e1bd6c407c6d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz\", \"integrity\": \"sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==\", \"time\": 0, \"size\": 13263, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "36857754e421caffd5edd1fe9f72240f1687ca050a9e09c5c3e701201011",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/6f"
+    },
+    {
+        "type": "inline",
         "contents": "f49a35b62fd925f40ce87761b764297787761c3d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz\", \"integrity\": \"sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==\", \"time\": 0, \"size\": 1816, \"metadata\": {\"url\": \"https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "483e6b07a338fc56daa546a5c7d73c769d72f488be87ff50117370bdf004",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/db"
@@ -7948,21 +6931,15 @@
     },
     {
         "type": "inline",
+        "contents": "f4b78b890403c96ba7148295f2d04263be11be14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.12.tgz\", \"integrity\": \"sha512-kpwXM7c/ayRUbYVErQbsZ0nQZX4aLHQrPEG9C4h9vuJCXylwFH8a7Jgi2VpKIObzCXO7LKHiCw4KdioFLFOgqA==\", \"time\": 0, \"size\": 8023, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e2090f690c265ca3306c3dc008d4653866b4a55b5ff59015655a9b0d0c02",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/36"
+    },
+    {
+        "type": "inline",
         "contents": "f4de916161c81da3f77da9a28fd35b7e69ce2f6f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz\", \"integrity\": \"sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==\", \"time\": 0, \"size\": 2950, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e150ac6f42a5580bba9d83a4666eb08d0f103c059c66a93d9b599f7c8c7f",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/77"
-    },
-    {
-        "type": "inline",
-        "contents": "f517a84d9743bfe02fd09a0dfa531a7f911d2882\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz\", \"integrity\": \"sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==\", \"time\": 0, \"size\": 8510, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ed647be75c932b444839ebb61d70cfe060a521d25480e7a2ee134e6027af",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/75"
-    },
-    {
-        "type": "inline",
-        "contents": "f51b16ff6d3d7b6940a9c33ab1d6e1b1e714b2a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.0.tgz\", \"integrity\": \"sha512-jc/4IxGNedXkmG4mx4nJTILb6TMjL66D41vyeaPWvDUmeYQzF3lKtN15WsAeTr65ce4mPxwopPSo1yUUAWw0hQ==\", \"time\": 0, \"size\": 74229, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "fe500410abf1110b46e96740fdfa403e7d85fa196821aa1b2a73c4f44a39",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/63"
     },
     {
         "type": "inline",
@@ -8008,6 +6985,12 @@
     },
     {
         "type": "inline",
+        "contents": "f7d3f7650411766b35b2def93ef5f39cc51e1e33\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz\", \"integrity\": \"sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==\", \"time\": 0, \"size\": 207830, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "31f9aa29658115263d61505a3e09112e36d5129f905de7c0188cf6ebe425",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/2a"
+    },
+    {
+        "type": "inline",
         "contents": "f82f4eaf6ed4573b6182b6d0fa60e60021c1adf0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob/-/glob-10.4.5.tgz\", \"integrity\": \"sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==\", \"time\": 0, \"size\": 71886, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob/-/glob-10.4.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9d3ad6d6b2b9d9132adb72c830494d1686dd0bc7f82667b4ddb3f9938550",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/90/ff"
@@ -8020,21 +7003,9 @@
     },
     {
         "type": "inline",
-        "contents": "f8996879ee03e2f89423307d78b67571c4666a07\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz\", \"integrity\": \"sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==\", \"time\": 0, \"size\": 6091, \"metadata\": {\"url\": \"https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "71ca2a86cecfc838f2d262d826aeaed3c7c05985e81095b4d24d53fa7d7b",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9c/48"
-    },
-    {
-        "type": "inline",
         "contents": "f8c9909baa38037ac38a337cbe93caeb877a68c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz\", \"integrity\": \"sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==\", \"time\": 0, \"size\": 3040, \"metadata\": {\"url\": \"https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "177c11d0147ed20d569acc59111a4be65dfdaa7862d2d5e8cb0463676b56",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/34"
-    },
-    {
-        "type": "inline",
-        "contents": "faf6cb4cd03393b8d74fac04ff332470caef2b18\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.7.1.tgz\", \"integrity\": \"sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==\", \"time\": 0, \"size\": 28361, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b032f72e0b485b4a88e2a296415ee616aeace938e762592ae999cd9ae807",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/61"
     },
     {
         "type": "inline",
@@ -8053,12 +7024,6 @@
         "contents": "fbbfb091d6d10a4c45453b4df079a750343dd4b1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz\", \"integrity\": \"sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==\", \"time\": 0, \"size\": 24561, \"metadata\": {\"url\": \"https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "81e485a43a0d0f46a5fb3aa04dfc18172be68dc872f60402b3933b26db82",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/47"
-    },
-    {
-        "type": "inline",
-        "contents": "fc27e183f7b21c5c58e318d75b916346cff1813c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz\", \"integrity\": \"sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==\", \"time\": 0, \"size\": 4330, \"metadata\": {\"url\": \"https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "49ad2e42668f2957917d329c1a628dcf4b15349783223f27eb035ddcea84",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/2b"
     },
     {
         "type": "inline",
@@ -8083,32 +7048,6 @@
         "contents": "fe1de1ff680c8d916c7726262158d78f4d91f892\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz\", \"integrity\": \"sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==\", \"time\": 0, \"size\": 2231, \"metadata\": {\"url\": \"https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "da67432c2cf29c75daef6eda49ba57e2e83b8962cb126f332ef78931ea1a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/85"
-    },
-    {
-        "type": "inline",
-        "contents": "fe3be2795a07dee62adcf9f689a764939e2e677a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz\", \"integrity\": \"sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==\", \"time\": 0, \"size\": 20116, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8b2fb003ec2153325def21f31d1966ffdb4a3ed787ae8c216eab1a597bd0",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/f7"
-    },
-    {
-        "type": "inline",
-        "contents": "febcfa2e4670f1bdca630bf376ef08abe72eada2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.0.tgz\", \"integrity\": \"sha512-kNiNU4/bhEQ/wutI1tp1pVW1mQ0QbAjfPRo5v8SaxoVV+ARhkB8Wjg3BSseNYECPzWWfg/WDqQGIfV1RaBFQZg==\", \"time\": 0, \"size\": 4174, \"metadata\": {\"url\": \"https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e06ffe096a7f486b8f7c4fd5bb75c93e756204ba445a1d60b85b4f7596d5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/84"
-    },
-    {
-        "type": "script",
-        "commands": [],
-        "dest-filename": "patch.sh",
-        "dest": "flatpak-node"
-    },
-    {
-        "type": "script",
-        "commands": [
-            "\"$FLATPAK_BUILDER_BUILDDIR\"/flatpak-node/patch.sh"
-        ],
-        "dest-filename": "patch-all.sh",
-        "dest": "flatpak-node"
     },
     {
         "type": "script",
@@ -8146,23 +7085,22 @@
     {
         "type": "shell",
         "commands": [
-            "FLATPAK_BUILDER_BUILDDIR=\"$PWD\" flatpak-node/patch-all.sh",
             "bash flatpak-node/setup_sdk_node_headers.sh"
         ]
     },
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"21906dece2bf154d833c39d4bf6cee061faf5be37b1ef21bf9d5564a0d4206cd\"",
-            "ln -s \"../SHASUMS256.txt-36.2.0\" \"21906dece2bf154d833c39d4bf6cee061faf5be37b1ef21bf9d5564a0d4206cd/SHASUMS256.txt\""
+            "mkdir -p \"3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd\"",
+            "ln -s \"../SHASUMS256.txt-36.2.1\" \"3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd/SHASUMS256.txt\""
         ],
         "dest": "flatpak-node/cache/electron"
     },
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"21906dece2bf154d833c39d4bf6cee061faf5be37b1ef21bf9d5564a0d4206cd\"",
-            "ln -s \"../electron-v36.2.0-linux-arm64.zip\" \"21906dece2bf154d833c39d4bf6cee061faf5be37b1ef21bf9d5564a0d4206cd/electron-v36.2.0-linux-arm64.zip\""
+            "mkdir -p \"3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd\"",
+            "ln -s \"../electron-v36.2.1-linux-arm64.zip\" \"3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd/electron-v36.2.1-linux-arm64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -8172,8 +7110,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"21906dece2bf154d833c39d4bf6cee061faf5be37b1ef21bf9d5564a0d4206cd\"",
-            "ln -s \"../electron-v36.2.0-linux-armv7l.zip\" \"21906dece2bf154d833c39d4bf6cee061faf5be37b1ef21bf9d5564a0d4206cd/electron-v36.2.0-linux-armv7l.zip\""
+            "mkdir -p \"3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd\"",
+            "ln -s \"../electron-v36.2.1-linux-armv7l.zip\" \"3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd/electron-v36.2.1-linux-armv7l.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -8183,8 +7121,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"21906dece2bf154d833c39d4bf6cee061faf5be37b1ef21bf9d5564a0d4206cd\"",
-            "ln -s \"../electron-v36.2.0-linux-x64.zip\" \"21906dece2bf154d833c39d4bf6cee061faf5be37b1ef21bf9d5564a0d4206cd/electron-v36.2.0-linux-x64.zip\""
+            "mkdir -p \"3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd\"",
+            "ln -s \"../electron-v36.2.1-linux-x64.zip\" \"3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd/electron-v36.2.1-linux-x64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -8194,8 +7132,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv36.2.0electron-v36.2.0-linux-arm64.zip\"",
-            "ln -s \"../electron-v36.2.0-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv36.2.0electron-v36.2.0-linux-arm64.zip/electron-v36.2.0-linux-arm64.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv36.2.1electron-v36.2.1-linux-arm64.zip\"",
+            "ln -s \"../electron-v36.2.1-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv36.2.1electron-v36.2.1-linux-arm64.zip/electron-v36.2.1-linux-arm64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -8205,8 +7143,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv36.2.0electron-v36.2.0-linux-armv7l.zip\"",
-            "ln -s \"../electron-v36.2.0-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv36.2.0electron-v36.2.0-linux-armv7l.zip/electron-v36.2.0-linux-armv7l.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv36.2.1electron-v36.2.1-linux-armv7l.zip\"",
+            "ln -s \"../electron-v36.2.1-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv36.2.1electron-v36.2.1-linux-armv7l.zip/electron-v36.2.1-linux-armv7l.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -8216,8 +7154,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv36.2.0electron-v36.2.0-linux-x64.zip\"",
-            "ln -s \"../electron-v36.2.0-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv36.2.0electron-v36.2.0-linux-x64.zip/electron-v36.2.0-linux-x64.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv36.2.1electron-v36.2.1-linux-x64.zip\"",
+            "ln -s \"../electron-v36.2.1-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv36.2.1electron-v36.2.1-linux-x64.zip/electron-v36.2.1-linux-x64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [


### PR DESCRIPTION
A new git source in [_node-gyp_](https://github.com/author-more/penpot-desktop/commit/4e8a1587663c3df9fa1cf02c06c215692a67dda3) [fails](https://github.com/flathub/com.authormore.penpotdesktop/actions/runs/15154916688/job/42607791469)  with ```NotImplementedError: Git sources in lockfile v2 format are not supported yet (package node_modules/@electron/node-gyp in package-lock.json)```, see https://github.com/flatpak/flatpak-builder-tools/issues/381

Locally generated with [Ian2020's PR](https://github.com/flatpak/flatpak-builder-tools/pull/382) but it seems very close to a merge so let's keep the action as is, I'll regenerate it manually as necessary.